### PR TITLE
Scale up apiserver

### DIFF
--- a/webhosting-operator/.run/experiment (kind).run.xml
+++ b/webhosting-operator/.run/experiment (kind).run.xml
@@ -1,8 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="experiment" type="GoApplicationRunConfiguration" factoryName="Go Application">
+  <configuration default="false" name="experiment (kind)" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="kubernetes-controller-sharding" />
     <working_directory value="$PROJECT_DIR$/webhosting-operator" />
     <parameters value="reconcile" />
+    <envs>
+      <env name="KUBECONFIG" value="$PROJECT_DIR$/webhosting-operator/dev/kind_kubeconfig.yaml" />
+    </envs>
     <kind value="PACKAGE" />
     <package value="github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/cmd/experiment" />
     <directory value="$PROJECT_DIR$" />

--- a/webhosting-operator/.run/webhosting-operator (kind).run.xml
+++ b/webhosting-operator/.run/webhosting-operator (kind).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="webhosting-operator process (kind)" type="GoApplicationRunConfiguration" factoryName="Go Application">
+  <configuration default="false" name="webhosting-operator (kind)" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="kubernetes-controller-sharding" />
     <working_directory value="$PROJECT_DIR$/webhosting-operator" />
     <envs>

--- a/webhosting-operator/Makefile
+++ b/webhosting-operator/Makefile
@@ -51,7 +51,7 @@ manifests: $(CONTROLLER_GEN) ## Generate WebhookConfiguration, ClusterRole and C
 	$(CONTROLLER_GEN) rbac:roleName=operator crd paths="./..." output:rbac:artifacts:config=config/manager/rbac output:crd:artifacts:config=config/manager/crds
 
 .PHONY: generate
-generate: $(CONTROLLER_GEN) ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: $(CONTROLLER_GEN) modules ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	hack/update-codegen.sh
 

--- a/webhosting-operator/config/experiment/base/job.yaml
+++ b/webhosting-operator/config/experiment/base/job.yaml
@@ -14,6 +14,9 @@ spec:
         image: experiment:latest
         args:
         - --zap-log-level=info
+        env:
+        - name: DISABLE_HTTP2
+          value: "true"
         ports:
         - name: metrics
           containerPort: 8080

--- a/webhosting-operator/config/external-dns/patch-deployment.yaml
+++ b/webhosting-operator/config/external-dns/patch-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         - --google-zone-visibility=public
         - --policy=sync
         - --registry=txt
-        - --txt-owner-id=shoot--timebertt--sharding-0e61b9e9-b7ce-4a71-a502-89f366015617-ond-460a37
+        - --txt-owner-id=shoot--timebertt--sharding-d657103c-eb4f-4a02-9af3-8ee7dc8d6e12-ond-82dc04
         - --interval=1m
         # ensure the records are not owned by short-lived acme solvers managed by cert-manager or website ingresses
         - --label-filter=acme.cert-manager.io/http01-solver!=true,app!=website

--- a/webhosting-operator/config/manager/default/manager.yaml
+++ b/webhosting-operator/config/manager/default/manager.yaml
@@ -18,6 +18,9 @@ spec:
         image: controller:latest
         args:
         - --zap-log-level=info
+        env:
+        - name: DISABLE_HTTP2
+          value: "true"
         ports:
         - name: metrics
           containerPort: 8080

--- a/webhosting-operator/config/policy/controlplane/kube-apiserver-scale.yaml
+++ b/webhosting-operator/config/policy/controlplane/kube-apiserver-scale.yaml
@@ -28,4 +28,4 @@ spec:
     mutate:
       patchStrategicMerge:
         spec:
-          replicas: 1
+          replicas: 4

--- a/webhosting-operator/config/policy/controlplane/kube-apiserver.yaml
+++ b/webhosting-operator/config/policy/controlplane/kube-apiserver.yaml
@@ -29,7 +29,7 @@ spec:
     mutate:
       patchStrategicMerge:
         spec:
-          replicas: 1
+          replicas: 4
   # set static requests/limits on kube-apiserver to ensure similar evaluation environment between load test runs
   - name: resources
     match:

--- a/webhosting-operator/config/policy/controlplane/tests/kube-apiserver-scale-awake/kyverno-test.yaml
+++ b/webhosting-operator/config/policy/controlplane/tests/kube-apiserver-scale-awake/kyverno-test.yaml
@@ -2,7 +2,7 @@ name: kube-apiserver-scale-awake
 policies:
 - ../../kube-apiserver-scale.yaml
 resources:
-# spec.replicas=2 -> expect spec.replicas=1
+# spec.replicas=2 -> expect spec.replicas=4
 - scale.yaml
 variables: variables.yaml
 results:

--- a/webhosting-operator/config/policy/controlplane/tests/kube-apiserver-scale-awake/scale_expected.yaml
+++ b/webhosting-operator/config/policy/controlplane/tests/kube-apiserver-scale-awake/scale_expected.yaml
@@ -4,4 +4,4 @@ metadata:
   name: kube-apiserver
   namespace: shoot--timebertt--sharding
 spec:
-  replicas: 1
+  replicas: 4

--- a/webhosting-operator/config/policy/controlplane/tests/kube-apiserver/kube-apiserver-awake_expected.yaml
+++ b/webhosting-operator/config/policy/controlplane/tests/kube-apiserver/kube-apiserver-awake_expected.yaml
@@ -7,7 +7,7 @@ metadata:
   name: kube-apiserver-awake
   namespace: shoot--timebertt--sharding
 spec:
-  replicas: 1
+  replicas: 4
   template:
     spec:
       containers:

--- a/webhosting-operator/config/policy/controlplane/tests/kube-apiserver/kube-apiserver-null_expected.yaml
+++ b/webhosting-operator/config/policy/controlplane/tests/kube-apiserver/kube-apiserver-null_expected.yaml
@@ -7,7 +7,7 @@ metadata:
   name: kube-apiserver-null
   namespace: shoot--timebertt--sharding
 spec:
-  replicas: 1
+  replicas: 4
   template:
     spec:
       containers:

--- a/webhosting-operator/config/policy/controlplane/tests/kube-apiserver/kyverno-test.yaml
+++ b/webhosting-operator/config/policy/controlplane/tests/kube-apiserver/kyverno-test.yaml
@@ -2,9 +2,9 @@ name: kube-apiserver
 policies:
 - ../../kube-apiserver.yaml
 resources:
-# spec.replicas=2 -> expect spec.replicas=1
+# spec.replicas=2 -> expect spec.replicas=4
 - kube-apiserver-awake.yaml
-# spec.replicas=null -> expect spec.replicas=1
+# spec.replicas=null -> expect spec.replicas=4
 - kube-apiserver-null.yaml
 # spec.replicas=0 -> expect skip
 - kube-apiserver-hibernated.yaml

--- a/webhosting-operator/config/policy/default/kustomization.yaml
+++ b/webhosting-operator/config/policy/default/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources: []

--- a/webhosting-operator/config/policy/shoot/kustomization.yaml
+++ b/webhosting-operator/config/policy/shoot/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../default
 - experiment-scheduling.yaml
 - scale-up-worker-experiment.yaml
 - webhosting-operator-scheduling.yaml

--- a/webhosting-operator/hack/update-codegen.sh
+++ b/webhosting-operator/hack/update-codegen.sh
@@ -29,7 +29,7 @@ EOF
 fi
 
 # fetch code-generator module to execute the scripts from the modcache (we don't vendor here)
-CODE_GENERATOR_DIR="$(go list -tags tools -f '{{ .Dir }}' k8s.io/code-generator)"
+CODE_GENERATOR_DIR="$(go list -m -tags tools -f '{{ .Dir }}' k8s.io/code-generator)"
 
 rm -f ${GOPATH}/bin/*-gen
 

--- a/webhosting-operator/shoot.yaml
+++ b/webhosting-operator/shoot.yaml
@@ -18,7 +18,7 @@ spec:
       nodeCIDRMaskSize: 20
     kubeProxy:
       mode: IPTables
-    version: "1.25"
+    version: "1.26"
     verticalPodAutoscaler:
       enabled: true
   maintenance:

--- a/webhosting-operator/skaffold.yaml
+++ b/webhosting-operator/skaffold.yaml
@@ -21,18 +21,6 @@ metadata:
 requires:
 - configs:
   - kyverno
-manifests:
-  kustomize:
-    paths:
-    - config/policy/default
-deploy:
-  kubectl:
-    defaultNamespace: ""
-    flags:
-      apply:
-      - --server-side
-      - --force-conflicts
-  statusCheck: false
 profiles:
 - name: shoot
   activation:
@@ -41,6 +29,14 @@ profiles:
     kustomize:
       paths:
       - config/policy/shoot
+  deploy:
+    kubectl:
+      defaultNamespace: ""
+      flags:
+        apply:
+        - --server-side
+        - --force-conflicts
+    statusCheck: false
 ---
 apiVersion: skaffold/v4beta6
 kind: Config


### PR DESCRIPTION
This PR follows up on https://github.com/timebertt/kubernetes-controller-sharding/pull/25 (https://github.com/timebertt/kubernetes-controller-sharding/commit/7899b35cf6f086229576e721068a8de768b2eb41 to be precise), where kube-apiserver was scaled down to a single instance as API request distribution across instances would vary between experiment runs.
Background: due to the simple SNI passthrough mechanism of Gardener, all API requests from a single controller land on a single API server instance as all reuse a single TLS/h2 connection.

However, the load test experiments hit a single API server's limits pretty quickly.
Instead of using a single instance, go back to 4 instances and disable HTTP/2 instead.
With this, we go back to pooling TLS connections for sequential reuse in multiple HTTP/1.1 requests.
This ensures a much more even distribution across API servers with a small performance penalty, which is good enough for reproducible evaluation results.

Also, this PR fixes two minor issues in the dev setup and upgrades the hosting cluster to 1.26.