### PR TITLE
Add persistent storage to parca

### DIFF
--- a/webhosting-operator/cmd/webhosting-operator/main.go
+++ b/webhosting-operator/cmd/webhosting-operator/main.go
@@ -250,7 +250,9 @@ func dropUnwantedMetadata(i interface{}) (interface{}, error) {
 	}
 
 	obj.SetManagedFields(nil)
-	delete(obj.GetAnnotations(), "kubectl.kubernetes.io/last-applied-configuration")
+	annotations := obj.GetAnnotations()
+	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
+	obj.SetAnnotations(annotations)
 
 	return obj, nil
 }

--- a/webhosting-operator/config/profiling/kustomization.yaml
+++ b/webhosting-operator/config/profiling/kustomization.yaml
@@ -2,11 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/parca-dev/parca/releases/download/v0.18.0/kubernetes-manifest.yaml
+- https://github.com/parca-dev/parca/releases/download/v0.20.0/kubernetes-manifest.yaml
 # provide parca running in namespace "parca" with the permissions required for service discovery in namespace
 # "webhosting-system" and scrape the pprof endpoints of webhosting-operator
 - parca_rbac.yaml
 - parca_ingress.yaml
+- parca-pvc.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -32,9 +33,18 @@ secretGenerator:
   - auth=parca_auth.secret.txt
 
 patches:
-- patch: |
-    apiVersion: policy/v1beta1
-    kind: PodSecurityPolicy
-    metadata:
-      name: parca
-    $patch: delete
+- path: patch-deployment-pvc.yaml
+- target:
+    kind: Deployment
+    name: parca
+    namespace: parca
+  patch: |
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --enable-persistence
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --storage-path=/var/lib/parca
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --storage-enable-wal

--- a/webhosting-operator/config/profiling/parca-pvc.yaml
+++ b/webhosting-operator/config/profiling/parca-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca
+    app.kubernetes.io/name: parca
+  name: parca
+  namespace: parca
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/webhosting-operator/config/profiling/patch-deployment-pvc.yaml
+++ b/webhosting-operator/config/profiling/patch-deployment-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: parca
+  namespace: parca
+spec:
+  # set replicas and strategy to play nicely with PVC
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    spec:
+      volumes:
+      - name: data
+        emptyDir: null
+        persistentVolumeClaim:
+          claimName: parca


### PR DESCRIPTION
Upgrade parca and enable persistent storage.

Also, fix the removal of the kubectl annotation in the sharder's cache.
This wasn't a problem in load tests, as none of the experiment objects have the kubectl annotation.