### PR TITLE
Container image improvements

### DIFF
--- a/.github/workflows/controller-sharding.yaml
+++ b/.github/workflows/controller-sharding.yaml
@@ -133,6 +133,8 @@ jobs:
         # prepare .ko.yaml to inject build settings into all images
         entrypoints=(
           ./cmd/sharder
+          ./hack/cmd/shard
+          ./hack/cmd/janitor
         )
         
         echo builds: > .ko.yaml

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,8 @@ kind-up: $(KIND) $(KUBECTL) ## Launch a kind cluster for local development and t
 kind-down: $(KIND) ## Tear down the kind testing cluster.
 	$(KIND) delete cluster --name sharding
 
+# use dedicated ghcr repo for dev images to prevent spamming the "production" image repo
+export SKAFFOLD_DEFAULT_REPO ?= ghcr.io/timebertt/dev-images
 export SKAFFOLD_FILENAME = hack/config/skaffold.yaml
 # use static label for skaffold to prevent rolling all components on every skaffold invocation
 deploy up dev down: export SKAFFOLD_LABEL = skaffold.dev/run-id=sharding

--- a/webhosting-operator/Makefile
+++ b/webhosting-operator/Makefile
@@ -118,6 +118,8 @@ images: $(KO) ## Build and push container images using ko.
 
 ##@ Deployment
 
+# use dedicated ghcr repo for dev images to prevent spamming the "production" image repo
+export SKAFFOLD_DEFAULT_REPO ?= ghcr.io/timebertt/dev-images
 # use static label for skaffold to prevent rolling all components on every skaffold invocation
 deploy up dev down: export SKAFFOLD_LABEL = skaffold.dev/run-id=webhosting-operator
 


### PR DESCRIPTION
- publish images for shard and janitor so that one can use `make deploy` for all components (i.e., deploy pre-built images)
- use dedicated ghcr repo for dev images (all dev images have been cleaned from ghcr)