### PR TITLE
Stop running actions on dev branches

### DIFF
--- a/.github/workflows/controller-sharding.yaml
+++ b/.github/workflows/controller-sharding.yaml
@@ -6,7 +6,7 @@ on:
     - published
   push:
     branches:
-    - '*'
+    - main
     tags:
     - v*
     paths-ignore:

--- a/.github/workflows/webhosting-operator.yaml
+++ b/.github/workflows/webhosting-operator.yaml
@@ -6,7 +6,7 @@ on:
     - published
   push:
     branches:
-    - '*'
+    - main
     tags:
     - v*
     paths:


### PR DESCRIPTION
Minimizes the amount of action runs (~> `sha-*` image tags) during development on branches in this repository.