### PR TITLE
Configure renovate changelog for prometheus-adapter

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -90,6 +90,11 @@
       matchDatasources: ["github-tags"],
       matchPackageNames: ["prometheus-operator/kube-prometheus"],
       prHeader: "⚠️ Manual action required ⚠️\nPlease check this PR out and run `hack/config/monitoring/update.sh`."
+    },
+    // help renovate fetch changelogs for packages that don't have any sourceUrl metadata attached
+    {
+      matchPackageNames: ["registry.k8s.io/prometheus-adapter/prometheus-adapter"],
+      customChangelogUrl: "https://github.com/kubernetes-sigs/prometheus-adapter"
     }
   ]
 }


### PR DESCRIPTION
Renovate can't autodetect the `sourceUrl` for `registry.k8s.io/prometheus-adapter/prometheus-adapter`.
Configure a `customChangelogUrl` to get changelogs nevertheless.