### PR TITLE
Upgrade kyverno to v1.10.7

### DIFF
--- a/hack/config/kyverno/kustomization.yaml
+++ b/hack/config/kyverno/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/kyverno/kyverno/releases/download/v1.10.4/install.yaml
+- https://github.com/kyverno/kyverno/releases/download/v1.10.7/install.yaml
 
 configMapGenerator:
 - name: kyverno

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -51,7 +51,7 @@ $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
 
 KYVERNO := $(TOOLS_BIN_DIR)/kyverno
 # renovate: datasource=github-tags depName=kyverno/kyverno
-KYVERNO_VERSION ?= v1.10.4
+KYVERNO_VERSION ?= v1.10.7
 $(KYVERNO): $(call tool_version_file,$(KYVERNO),$(KYVERNO_VERSION))
 	curl -Lo - https://github.com/kyverno/kyverno/releases/download/$(KYVERNO_VERSION)/kyverno-cli_$(KYVERNO_VERSION)_$(shell uname -s | tr '[:upper:]' '[:lower:]')_$(shell uname -m | sed 's/aarch64/arm64/').tar.gz | tar -xzmf - -C $(TOOLS_BIN_DIR) kyverno
 	chmod +x $(KYVERNO)

--- a/webhosting-operator/Makefile
+++ b/webhosting-operator/Makefile
@@ -65,10 +65,6 @@ modules: ## Runs go mod to ensure modules are up to date.
 test: $(SETUP_ENVTEST) ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -race ./...
 
-.PHONY: test-kyverno
-test-kyverno: $(KYVERNO) ## Run kyverno policy tests.
-	$(KYVERNO) test --remove-color -v 4 .
-
 .PHONY: skaffold-fix
 skaffold-fix: $(SKAFFOLD) ## Upgrade skaffold configuration to the latest apiVersion.
 	$(SKAFFOLD) fix --overwrite
@@ -81,7 +77,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: check
-check: vet test test-kyverno ## Check everything (vet + test + test-kyverno).
+check: vet test ## Check everything (vet + test).
 
 .PHONY: verify-fmt
 verify-fmt: fmt ## Verify go code is formatted.

--- a/webhosting-operator/tools.mk
+++ b/webhosting-operator/tools.mk
@@ -43,13 +43,6 @@ $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
 	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(shell uname -s | tr '[:upper:]' '[:lower:]')/$(shell uname -m | sed 's/x86_64/amd64/')/kubectl
 	chmod +x $(KUBECTL)
 
-KYVERNO := $(TOOLS_BIN_DIR)/kyverno
-# renovate: datasource=github-tags depName=kyverno/kyverno
-KYVERNO_VERSION ?= v1.10.3
-$(KYVERNO): $(call tool_version_file,$(KYVERNO),$(KYVERNO_VERSION))
-	curl -Lo - https://github.com/kyverno/kyverno/releases/download/$(KYVERNO_VERSION)/kyverno-cli_$(KYVERNO_VERSION)_$(shell uname -s | tr '[:upper:]' '[:lower:]')_$(shell uname -m | sed 's/aarch64/arm64/').tar.gz | tar -xzmf - -C $(TOOLS_BIN_DIR) kyverno
-	chmod +x $(KYVERNO)
-
 SETUP_ENVTEST := $(TOOLS_BIN_DIR)/setup-envtest
 $(SETUP_ENVTEST): go.mod
 	go build -o $(SETUP_ENVTEST) sigs.k8s.io/controller-runtime/tools/setup-envtest


### PR DESCRIPTION
As we cannot upgrade to kyverno v1.11 (ref https://github.com/timebertt/kubernetes-controller-sharding/pull/54#issuecomment-1867500948), upgrade to the latest patch of v1.10 instead.