### PR TITLE
Fix renovate config for ingress-nginx

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -95,7 +95,7 @@
       // special case for ingress-nginx: version is prefixed with `controller-`
       matchDatasources: ["github-tags"],
       matchPackageNames: ["kubernetes/ingress-nginx"],
-      extractVersion: "^controller-(?<version>.+)$"
+      "versionCompatibility": "^(?<compatibility>.*)-(?<version>.+)$"
     },
     {
       // manual action required: upgrading kube-prometheus is not fully automated yet

--- a/hack/config/ingress-nginx/default/kustomization.yaml
+++ b/hack/config/ingress-nginx/default/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: ingress-nginx
 
 resources:
-- https://raw.githubusercontent.com/kubernetes/ingress-nginx/v1.9.5/deploy/static/provider/cloud/deploy.yaml
+- https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.9.4/deploy/static/provider/cloud/deploy.yaml
 
 patches:
 - path: patch_default_ingress_class.yaml


### PR DESCRIPTION
Fixes https://github.com/timebertt/kubernetes-controller-sharding/pull/46

`extractVersion` should only be used when the datasource returns a version string that doesn't match the one in the repository.
We need `versionCompatibility` instead.