### PR TITLE
Rename renovate kubectl dependency

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -43,7 +43,7 @@ $(KO): $(call tool_version_file,$(KO),$(KO_VERSION))
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/google/ko@$(KO_VERSION)
 
 KUBECTL := $(TOOLS_BIN_DIR)/kubectl
-# renovate: datasource=github-tags depName=kubernetes/kubernetes
+# renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubernetes
 KUBECTL_VERSION ?= v1.29.0
 $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
 	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(shell uname -s | tr '[:upper:]' '[:lower:]')/$(shell uname -m | sed 's/x86_64/amd64/')/kubectl

--- a/webhosting-operator/tools.mk
+++ b/webhosting-operator/tools.mk
@@ -37,7 +37,7 @@ $(KO): $(call tool_version_file,$(KO),$(KO_VERSION))
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/google/ko@$(KO_VERSION)
 
 KUBECTL := $(TOOLS_BIN_DIR)/kubectl
-# renovate: datasource=github-tags depName=kubernetes/kubernetes
+# renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubernetes
 KUBECTL_VERSION ?= v1.29.0
 $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
 	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(shell uname -s | tr '[:upper:]' '[:lower:]')/$(shell uname -m | sed 's/x86_64/amd64/')/kubectl


### PR DESCRIPTION
**What this PR does / why we need it**:

Gives the kubectl tool dependency a proper name in renovate.

**Which issue(s) this PR fixes**:

PR titles like https://github.com/timebertt/kubernetes-controller-sharding/pull/103 are confusing.

**Special notes for your reviewer**:
