### PR TITLE
Enable automerge for kubernetes patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,17 +47,47 @@
   ],
   packageRules: [
     {
-      // bump k8s and controller-runtime dependencies together
+      // bump k8s and controller-runtime go dependencies together
       groupName: "k8s packages",
       groupSlug: "k8s-go",
       matchDatasources: ["go"],
-      matchPackagePrefixes: ["k8s.io/", "sigs.k8s.io/controller-runtime"]
+      matchPackagePrefixes: [
+        // from "group:kubernetes"
+        "k8s.io/api",
+        "k8s.io/apiextensions-apiserver",
+        "k8s.io/apimachinery",
+        "k8s.io/apiserver",
+        "k8s.io/cli-runtime",
+        "k8s.io/client-go",
+        "k8s.io/cloud-provider",
+        "k8s.io/cluster-bootstrap",
+        "k8s.io/code-generator",
+        "k8s.io/component-base",
+        "k8s.io/controller-manager",
+        "k8s.io/cri-api",
+        "k8s.io/csi-translation-lib",
+        "k8s.io/kube-aggregator",
+        "k8s.io/kube-controller-manager",
+        "k8s.io/kube-proxy",
+        "k8s.io/kube-scheduler",
+        "k8s.io/kubectl",
+        "k8s.io/kubelet",
+        "k8s.io/legacy-cloud-providers",
+        "k8s.io/metrics",
+        "k8s.io/mount-utils",
+        "k8s.io/pod-security-admission",
+        "k8s.io/sample-apiserver",
+        "k8s.io/sample-cli-plugin",
+        "k8s.io/sample-controller",
+        // added packages
+        "sigs.k8s.io/controller-runtime"
+      ]
     },
     {
       // separate k8s patch updates (keep in sync with the next package rule)
       matchPackagePrefixes: [
         // datasource=go
-        "k8s.io/",
+        "k8s.io/", // includes more than the k8s-go group! (e.g., k8s.io/utils)
         "sigs.k8s.io/controller-runtime",
         // datasource=github-tags
         "kubernetes/kubernetes",
@@ -69,7 +99,7 @@
       // automerge k8s patch updates (keep in sync with the previous package rule)
       matchPackagePrefixes: [
         // datasource=go
-        "k8s.io/",
+        "k8s.io/", // includes more than the k8s-go group! (e.g., k8s.io/utils)
         "sigs.k8s.io/controller-runtime",
         // datasource=github-tags
         "kubernetes/kubernetes",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,7 @@
   ],
   labels: ["dependencies"],
   postUpdateOptions: ["gomodTidy"],
+  automergeStrategy: "squash",
   kubernetes: {
     fileMatch: ["\\.yaml$"]
   },
@@ -51,6 +52,31 @@
       groupSlug: "k8s-go",
       matchDatasources: ["go"],
       matchPackagePrefixes: ["k8s.io/", "sigs.k8s.io/controller-runtime"]
+    },
+    {
+      // separate k8s patch updates (keep in sync with the next package rule)
+      matchPackagePrefixes: [
+        // datasource=go
+        "k8s.io/",
+        "sigs.k8s.io/controller-runtime",
+        // datasource=github-tags
+        "kubernetes/kubernetes",
+        "kubernetes-sigs/controller-tools"
+      ],
+      separateMinorPatch: true
+    },
+    {
+      // automerge k8s patch updates (keep in sync with the previous package rule)
+      matchPackagePrefixes: [
+        // datasource=go
+        "k8s.io/",
+        "sigs.k8s.io/controller-runtime",
+        // datasource=github-tags
+        "kubernetes/kubernetes",
+        "kubernetes-sigs/controller-tools"
+      ],
+      matchUpdateTypes: ["patch", "digest"],
+      automerge: true
     },
     {
       // setup-envtest is not tagged, don't create a PR for every commit in controller-runtime

--- a/.github/workflows/controller-sharding.yaml
+++ b/.github/workflows/controller-sharding.yaml
@@ -8,11 +8,12 @@ on:
     - v*
     paths-ignore:
     - "webhosting-operator/**"
+    - ".github/workflows/webhosting-operator.yaml"
     - "**.md"
   pull_request:
     paths-ignore:
     - "webhosting-operator/**"
-    - "**.md"
+    - ".github/workflows/webhosting-operator.yaml"
 
 jobs:
   verify:

--- a/.github/workflows/webhosting-operator.yaml
+++ b/.github/workflows/webhosting-operator.yaml
@@ -14,7 +14,6 @@ on:
     paths:
     - "webhosting-operator/**"
     - ".github/workflows/webhosting-operator.yaml"
-    - "!**.md"
 
 jobs:
   verify:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures we can use GitHub's automerge feature and enables renovate automerge for k8s patch updates.
Only group k8s go deps that are released together (e.g., don't include `k8s.io/utils` or `k8s.io/klog`).