### PR TITLE
Measure controller SLIs in load tests

### DIFF
--- a/webhosting-operator/config/experiment/base/rbac.yaml
+++ b/webhosting-operator/config/experiment/base/rbac.yaml
@@ -43,6 +43,21 @@ rules:
   verbs:
   - create
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - deletecollection
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - deletecollection
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/webhosting-operator/pkg/experiment/generator/theme.go
+++ b/webhosting-operator/pkg/experiment/generator/theme.go
@@ -87,7 +87,7 @@ func MutateRandomTheme(ctx context.Context, c client.Client, labels map[string]s
 	}
 
 	if len(themeList.Items) == 0 {
-		log.V(1).Info("No themes created yet, skipping mutation")
+		log.V(1).Info("No themes found, skipping mutation")
 		return nil
 	}
 

--- a/webhosting-operator/pkg/experiment/generator/theme.go
+++ b/webhosting-operator/pkg/experiment/generator/theme.go
@@ -94,13 +94,3 @@ func MutateRandomTheme(ctx context.Context, c client.Client, labels map[string]s
 	theme := utils.PickRandom(themeList.Items)
 	return MutateTheme(ctx, c, &theme)
 }
-
-// CleanupThemes deletes all themes with the given labels.
-func CleanupThemes(ctx context.Context, c client.Client, labels map[string]string) error {
-	if err := c.DeleteAllOf(ctx, &webhostingv1alpha1.Theme{}, client.MatchingLabels(labels)); err != nil {
-		return err
-	}
-
-	log.V(1).Info("Cleaned up all project themes")
-	return nil
-}

--- a/webhosting-operator/pkg/experiment/scenario/base/base.go
+++ b/webhosting-operator/pkg/experiment/scenario/base/base.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/experiment/generator"
+	"github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/experiment/tracker"
 )
 
 // Scenario provides a common base implemenation for parts of the experiment.Scenario interface.
@@ -120,6 +121,12 @@ func (s *Scenario) Start(ctx context.Context) (err error) {
 		return ctx.Err()
 	case <-time.After(30 * time.Second):
 	}
+
+	websiteTracker := &tracker.WebsiteTracker{}
+	if err := websiteTracker.AddToManager(s.Manager); err != nil {
+		return fmt.Errorf("error adding website-tracker: %w", err)
+	}
+	generator.SetWebsiteTracker(websiteTracker)
 
 	if err := s.Delegate.Run(ctx); err != nil {
 		return err

--- a/webhosting-operator/pkg/experiment/scenario/base/base.go
+++ b/webhosting-operator/pkg/experiment/scenario/base/base.go
@@ -18,10 +18,15 @@ package base
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -77,28 +82,21 @@ func (s *Scenario) Start(ctx context.Context) (err error) {
 	defer close(s.done)
 	s.Log.Info("Scenario started")
 
-	s.Log.Info("Creating owner object")
-	ownerObject, ownerRef, err := generator.CreateClusterScopedOwnerObject(ctx, s.Client, generator.WithLabels(s.Labels))
+	cleanup, err := s.prepare(ctx)
 	if err != nil {
 		return err
 	}
-	s.OwnerRef = ownerRef
-
-	// use unique label set per scenario run
-	s.Labels["run-id"] = string(ownerObject.GetUID())
-	s.Log = s.Log.WithValues("runID", s.Labels["run-id"])
-	s.Log.Info("Created owner object", "object", ownerObject)
 
 	defer func() {
 		s.Log.Info("Cleaning up")
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		if cleanupErr := s.Client.Delete(cleanupCtx, ownerObject, client.PropagationPolicy(metav1.DeletePropagationForeground)); cleanupErr != nil {
+		if cleanupErr := cleanup(cleanupCtx); cleanupErr != nil {
 			// if another error occurred during execution, it has priority
 			// otherwise, return the cleanup error
 			if err != nil {
-				s.Log.Error(cleanupErr, "Failed cleaning up owner object", "object", ownerObject)
+				s.Log.Error(cleanupErr, "Failed cleaning up")
 			} else {
 				err = cleanupErr
 			}
@@ -137,5 +135,89 @@ func (s *Scenario) Start(ctx context.Context) (err error) {
 	}
 
 	s.Log.Info("Scenario finished")
+	return nil
+}
+
+func (s *Scenario) prepare(ctx context.Context) (func(context.Context) error, error) {
+	s.Log.Info("Creating owner object")
+	ownerObject, ownerRef, err := generator.CreateClusterScopedOwnerObject(ctx, s.Client, generator.WithLabels(s.Labels))
+	if err != nil {
+		return nil, err
+	}
+	s.OwnerRef = ownerRef
+
+	// use unique label set per scenario run
+	s.Labels["run-id"] = string(ownerObject.GetUID())
+	s.Log = s.Log.WithValues("runID", s.Labels["run-id"])
+	s.Log.Info("Created owner object", "object", ownerObject)
+
+	cleanup := func(cleanupCtx context.Context) error {
+		if err := s.Client.Delete(cleanupCtx, ownerObject, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+			return fmt.Errorf("failed cleaning up owner object %T %s", ownerObject, client.ObjectKeyFromObject(ownerObject))
+		}
+		return nil
+	}
+
+	s.Log.Info("Restarting observed components")
+
+	// restart observed components to start from a fresh state
+	if err := s.Client.DeleteAllOf(ctx, &corev1.Pod{},
+		client.InNamespace("sharding-system"), client.MatchingLabels{"app.kubernetes.io/component": "sharder"},
+	); err != nil {
+		return nil, err
+	}
+	if err := s.Client.DeleteAllOf(ctx, &corev1.Pod{},
+		client.InNamespace("webhosting-system"), client.MatchingLabels{"app.kubernetes.io/name": "webhosting-operator"},
+	); err != nil {
+		return nil, err
+	}
+
+	// clean up orphaned leases after instances have been terminated
+	select {
+	case <-ctx.Done():
+		s.Log.Info("Scenario cancelled")
+		return nil, ctx.Err()
+	case <-time.After(5 * time.Second):
+	}
+
+	if err := s.Client.DeleteAllOf(ctx, &coordinationv1.Lease{},
+		client.InNamespace("webhosting-system"), client.MatchingLabels{"alpha.sharding.timebertt.dev/state": "dead"},
+	); err != nil {
+		return nil, err
+	}
+
+	// wait for all shard leases to be ready
+	if err := s.waitForShardLeases(ctx); err != nil {
+		return nil, fmt.Errorf("failed waiting for shard leases: %w", err)
+	}
+
+	return cleanup, nil
+}
+
+func (s *Scenario) waitForShardLeases(ctx context.Context) error {
+	var lastError error
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		leaseList := &coordinationv1.LeaseList{}
+		if err := s.Client.List(ctx, leaseList,
+			client.InNamespace("webhosting-system"), client.MatchingLabels{"alpha.sharding.timebertt.dev/clusterring": "webhosting-operator"},
+		); err != nil {
+			return true, err
+		}
+
+		for _, lease := range leaseList.Items {
+			state := lease.Labels["alpha.sharding.timebertt.dev/state"]
+			if state != "ready" {
+				lastError = fmt.Errorf("shard lease %s is in state %q", client.ObjectKeyFromObject(&lease), state)
+				return false, nil
+			}
+		}
+
+		return true, nil
+	}); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return lastError
+		}
+		return err
+	}
 	return nil
 }

--- a/webhosting-operator/pkg/experiment/scenario/basic/basic.go
+++ b/webhosting-operator/pkg/experiment/scenario/basic/basic.go
@@ -55,7 +55,6 @@ func (s *scenario) LongDescription() string {
 - website creation: 8000 over 10m
 - website deletion: 600 over 10m
 - website reconciliation: max 130/s
-- theme reconciliation: 1/m -> triggers reconciliation of all referencing websites
 `
 }
 
@@ -109,19 +108,6 @@ func (s *scenario) Run(ctx context.Context) error {
 		Every: time.Minute,
 	}).AddToManager(s.Manager); err != nil {
 		return fmt.Errorf("error adding website-mutator: %w", err)
-	}
-
-	// update one theme every minute which causes all referencing websites to be reconciled
-	// => peaks at about 2.6 reconciliations per second on average
-	// (note: these reconciliation triggers occur in bursts of up to ~156)
-	if err := (&generator.Every{
-		Name: "theme-mutator",
-		Do: func(ctx context.Context, c client.Client) error {
-			return generator.MutateRandomTheme(ctx, c, s.Labels)
-		},
-		Rate: rate.Every(time.Minute),
-	}).AddToManager(s.Manager); err != nil {
-		return fmt.Errorf("error adding theme-mutator: %w", err)
 	}
 
 	return nil

--- a/webhosting-operator/pkg/experiment/tracker/tracker.go
+++ b/webhosting-operator/pkg/experiment/tracker/tracker.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracker
+
+import (
+	"cmp"
+	"slices"
+	"sync"
+)
+
+// tracker is a generic map that only allows manipulating keys via the set operation ("create or update").
+// It synchronizes access to the map itself, but not to the contained values. Values need to synchronize concurrent
+// access on their own.
+// This is done to efficiently store multi-level tracking information in a concurrency safe way.
+type tracker[K cmp.Ordered, V any] struct {
+	lock   sync.RWMutex
+	values map[K]*V
+	new    func() *V
+}
+
+// sortedValues returns a slice of values in the tracker's map sorted by their respective keys.
+func (t *tracker[K, V]) sortedValues() []*V {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	keys := make([]K, 0, len(t.values))
+	for k := range t.values {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	values := make([]*V, 0, len(t.values))
+	for _, k := range keys {
+		values = append(values, t.values[k])
+	}
+
+	return values
+}
+
+// set adds a new key to the map and runs mutate on its value, or mutates the value of an existing key.
+func (t *tracker[K, V]) set(key K, mutate func(v *V)) {
+	// fast path for existing keys
+	t.lock.RLock()
+	if v, ok := t.values[key]; ok {
+		defer t.lock.RUnlock()
+		mutate(v)
+		return
+	}
+
+	// slow path for new keys
+	// upgrade lock for adding new keys
+	t.lock.RUnlock()
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// re-check for concurrent additions
+	if v, ok := t.values[key]; ok {
+		mutate(v)
+		return
+	}
+
+	// add new key
+	var v *V
+	if t.new != nil {
+		v = t.new()
+	} else {
+		v = new(V)
+	}
+
+	t.values[key] = v
+	mutate(v)
+}

--- a/webhosting-operator/pkg/experiment/tracker/website.go
+++ b/webhosting-operator/pkg/experiment/tracker/website.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2024 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracker
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	webhostingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/apis/webhosting/v1alpha1"
+)
+
+var (
+	websiteReconciliationLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "experiment",
+		Subsystem: "website",
+		Name:      "reconciliation_duration_seconds",
+		Help: "Latency from Website creation or spec update until the generation is observed as ready by a watch. " +
+			"This is an SLI for controller performance.",
+		Buckets: prometheus.ExponentialBuckets(0.025, 2, 14),
+	})
+	websiteBackfilledGenerations = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "experiment",
+		Subsystem: "website",
+		Name:      "backfilled_generations_total",
+		Help: "Counter for Website generations that were never observed as ready before the next generation appeared. " +
+			"For such generations, the time when the next generation got ready is used for calculating the reconciliation latency. " +
+			"This metric serves as an indicator for how accurate the reconciliation latency measurement is.",
+	})
+	watchLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "experiment",
+		Name:      "watch_latency_seconds",
+		Help: "Latency from Website transition time until observed by a watch event in experiment. " +
+			"This metric serves as an indicator for how experiment itself is performing to ensure accurate measurements.",
+		Buckets: prometheus.ExponentialBuckets(0.025, 2, 14),
+	})
+)
+
+// WebsiteTracker tracks how long it takes for generations of Website objects to be reconciled and get ready.
+type WebsiteTracker struct {
+	reader client.Reader
+
+	// objects maps an object's UID to the object's generation information.
+	// The UID is used as the key instead of a namespaced name so that the tracker can distinguish between object
+	// instances with the same namespaced name.
+	objects *tracker[types.UID, objectGenerations]
+}
+
+// objectGenerations stores information about all generations of a single object.
+type objectGenerations struct {
+	lock        sync.Mutex
+	generations *tracker[int64, generationTimes]
+}
+
+// generationTimes stores information about a single generation of an object.
+// It doesn't synchronize access. Access is synchronized by the lock on objectGenerations level.
+type generationTimes struct {
+	created, ready time.Time
+	recorded       bool
+}
+
+func newObjectsTracker() *tracker[types.UID, objectGenerations] {
+	return &tracker[types.UID, objectGenerations]{
+		values: map[types.UID]*objectGenerations{},
+		new: func() *objectGenerations {
+			return &objectGenerations{
+				generations: newGenerationsTracker(),
+			}
+		},
+	}
+}
+
+func newGenerationsTracker() *tracker[int64, generationTimes] {
+	return &tracker[int64, generationTimes]{
+		values: map[int64]*generationTimes{},
+	}
+}
+
+// AddToManager initializes the tracker, registers its metrics, and starts watching objects.
+func (w *WebsiteTracker) AddToManager(mgr manager.Manager) error {
+	if w.reader == nil {
+		w.reader = mgr.GetCache()
+	}
+
+	w.objects = newObjectsTracker()
+
+	// initialize counters
+	websiteBackfilledGenerations.Add(0)
+
+	// register all metrics
+	metrics.Registry.MustRegister(websiteReconciliationLatency, websiteBackfilledGenerations, watchLatency)
+
+	return builder.ControllerManagedBy(mgr).
+		Named("website-tracker").
+		Watches(&webhostingv1alpha1.Website{}, w.websiteHandler(), builder.WithPredicates(w.observedNewReadyGeneration())).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 5,
+		}).
+		Complete(w)
+}
+
+// websiteHandler enqueues the object's UID for update requests.
+// It concurrently adds the observed status to the tracker and enqueues the object for reconciliation with a short delay
+// to give the tracker enough time to store the observed status.
+// This reduces the number of requeues we need to do for waiting for the ready timestamp to arrive in the tracker.
+func (w *WebsiteTracker) websiteHandler() handler.EventHandler {
+	return handler.Funcs{
+		UpdateFunc: func(_ context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+			website, ok := e.ObjectNew.(*webhostingv1alpha1.Website)
+			if !ok {
+				return
+			}
+
+			w.recordStatusGeneration(website)
+
+			q.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{
+				Name: string(website.UID),
+			}}, time.Second)
+		},
+	}
+}
+
+// observedNewReadyGeneration returns a predicate that triggers when a new generation is observed to be ready and its
+// reconciliation latency should be recorded by the reconciler.
+func (w *WebsiteTracker) observedNewReadyGeneration() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldWebsite, ok := e.ObjectOld.(*webhostingv1alpha1.Website)
+			if !ok {
+				return false
+			}
+			website, ok := e.ObjectNew.(*webhostingv1alpha1.Website)
+			if !ok {
+				return false
+			}
+
+			// Record how long it took experiment to observe the transition.
+			if t := website.Status.LastTransitionTime; t != nil && !t.Equal(oldWebsite.Status.LastTransitionTime) {
+				watchLatency.Observe(time.Since(t.Time).Seconds())
+			}
+
+			// if the status changed and the website is ready, we observed a new generation becoming ready
+			return !apiequality.Semantic.DeepEqual(oldWebsite.Status, website.Status) &&
+				website.Status.Phase == webhostingv1alpha1.PhaseReady
+		},
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}
+
+// RecordSpecChange records a new generation of the given website as created or updated by the experiment.
+// Supposed to be called by the load generator.
+func (w *WebsiteTracker) RecordSpecChange(website *webhostingv1alpha1.Website) {
+	// record time first, before locking
+	t := time.Now()
+
+	// store time concurrently, so that we don't block the load generator
+	go w.objects.set(website.UID, func(generations *objectGenerations) {
+		generations.setGenerationCreated(website.Generation, t)
+	})
+}
+
+// recordStatusGeneration records a new observed generation of the given website if it is ready.
+// Supposed to be called by the watch handler (synchronously).
+func (w *WebsiteTracker) recordStatusGeneration(website *webhostingv1alpha1.Website) {
+	// record time first, before locking
+	t := time.Now()
+
+	// store time concurrently, so that we don't block the watch handler/reflector
+	go w.objects.set(website.UID, func(generations *objectGenerations) {
+		generations.setGenerationReady(website.Status.ObservedGeneration, t)
+	})
+}
+
+// setGenerationCreated records the time when the given generation was created, i.e., when the creation / spec change
+// happened.
+func (o *objectGenerations) setGenerationCreated(generation int64, t time.Time) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	o.generations.set(generation, func(times *generationTimes) {
+		if !times.created.IsZero() {
+			// generation was already recorded
+			return
+		}
+
+		times.created = t
+	})
+}
+
+// setGenerationReady records the time when the given generation was observed as ready.
+func (o *objectGenerations) setGenerationReady(generation int64, t time.Time) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	o.generations.set(generation, func(times *generationTimes) {
+		if !times.ready.IsZero() {
+			// generation was already recorded
+			return
+		}
+
+		times.ready = t
+	})
+}
+
+// Reconcile iterates over all objects and records metrics for the generations that were observed to be ready.
+func (w *WebsiteTracker) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+	uid := types.UID(req.Name)
+
+	var res reconcile.Result
+	w.objects.set(uid, func(generations *objectGenerations) {
+		res = generations.reconcile(log)
+	})
+	return res, nil
+}
+
+// reconcile iterates over the object's generations and records newly observed finished reconciliations in the latency
+// metric.
+func (o *objectGenerations) reconcile(log logr.Logger) reconcile.Result {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	generations := generationsList(o.generations.sortedValues())
+	generations.backfillGenerations()
+
+	if finished := generations.recordNewReadyGenerations(log); !finished {
+		return reconcile.Result{Requeue: true}
+	}
+
+	return reconcile.Result{}
+}
+
+type generationsList []*generationTimes
+
+// backfillGenerations backfills the ready time for generations if we observed a newer ready generation.
+// This might be necessary if we missed some watch events, or multiple generations were created in quick succession
+// where only a later one was reconciled by the controller to be ready.
+// The generations slice must be sorted by generation in ascending order.
+func (gg generationsList) backfillGenerations() {
+	var newerReadyTime time.Time
+	for i := len(gg) - 1; i >= 0; i-- {
+		g := gg[i]
+
+		if g.recorded {
+			continue
+		}
+
+		if g.ready.IsZero() {
+			// this generation was not observed as ready,
+			// copy the ready time from the generation after it (if it has been observed as ready)
+			g.ready = newerReadyTime
+			websiteBackfilledGenerations.Add(1)
+		} else {
+			// this generation was observed as ready, copy the timestamp for backfilling earlier generations.
+			newerReadyTime = g.ready
+		}
+	}
+}
+
+// recordNewReadyGenerations records all newly observed ready generations.
+// Returns true if all generations have been recorded, false if there are unready generations left.
+func (gg generationsList) recordNewReadyGenerations(log logr.Logger) bool {
+	finished := true
+	for _, g := range gg {
+		if g.recorded {
+			continue
+		}
+		if g.created.IsZero() || g.ready.IsZero() {
+			finished = false
+			continue
+		}
+
+		latency := g.ready.Sub(g.created)
+		logLevel := 1
+		if latency > 30*time.Second {
+			logLevel = 0
+		}
+		log.V(logLevel).Info("Observed ready website", "latency", latency, "created", g.created, "ready", g.ready)
+
+		websiteReconciliationLatency.Observe(latency.Seconds())
+		g.recorded = true
+	}
+
+	return finished
+}

--- a/webhosting-operator/skaffold.yaml
+++ b/webhosting-operator/skaffold.yaml
@@ -139,6 +139,17 @@ profiles:
                       exit 1
                     fi
                     kubectl -n experiment delete job experiment --ignore-not-found --wait=true
+            - host:
+                command:
+                  - /usr/bin/env
+                  - bash
+                  - -c
+                  - |
+                    if kubectl get clusterring example &>/dev/null || kubectl -n default get deploy shard &>/dev/null ; then
+                      echo "Example shard is still running, refusing to run a load test experiment."
+                      echo "Ensure a clean load test environment, i.e., run 'make down SKAFFOLD_MODULE=shard'."
+                      exit 1
+                    fi
 ---
 apiVersion: skaffold/v4beta9
 kind: Config

--- a/webhosting-operator/skaffold.yaml
+++ b/webhosting-operator/skaffold.yaml
@@ -133,7 +133,7 @@ profiles:
                   - bash
                   - -c
                   - |
-                    active_pods="$(kubectl -n experiment get job experiment -ojsonpath='{.status.active}' 2>dev/null)"
+                    active_pods="$(kubectl -n experiment get job experiment -ojsonpath='{.status.active}' 2>/dev/null)"
                     if [ "${active_pods:-0}" -gt 0 ] && [ -z "$EXPERIMENT_DELETE_FORCE" ] ; then
                       echo "Experiment is running currently, refusing to delete the job. Set EXPERIMENT_DELETE_FORCE to override."
                       exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:

The SLIs of a controller are:
- queue latency
- reconciliation latency (the time it takes from object creation/spec update until it is ready and observed by a watch)

This PR improves the experiment tool to
- make triggered reconciliations measurable (mutate Website specs instead of triggering reconciliation via an annotation, don't use secondary reconciliation triggers (changing Theme spec))
- track reconciliations (Website generations) and measure the reconciliation latency
- not mutate spec immediately after creation (the first generation will rarely get ready)
- ensure a clean test environment for better reproducibility