### PR TITLE
Website controller: wait for deployment to be rolled out

### DIFF
--- a/webhosting-operator/pkg/utils/kubernetes.go
+++ b/webhosting-operator/pkg/utils/kubernetes.go
@@ -18,6 +18,9 @@ package utils
 
 import (
 	"os"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // RunningInCluster implements a heuristic for determining whether the process is running in a cluster or not.
@@ -28,4 +31,37 @@ func RunningInCluster() bool {
 	}
 
 	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
+}
+
+// IsDeploymentReady returns true if the current generation has been observed by the deployment controller and has been
+// fully rolled out.
+func IsDeploymentReady(deployment *appsv1.Deployment) bool {
+	if deployment.Status.ObservedGeneration < deployment.Generation {
+		return false
+	}
+
+	available := GetDeploymentCondition(deployment.Status.Conditions, appsv1.DeploymentAvailable)
+	if available == nil || available.Status != corev1.ConditionTrue {
+		return false
+	}
+
+	progressing := GetDeploymentCondition(deployment.Status.Conditions, appsv1.DeploymentProgressing)
+	if progressing == nil || progressing.Status != corev1.ConditionTrue || progressing.Reason != "NewReplicaSetAvailable" {
+		// only if Progressing is in status True with reason NewReplicaSetAvailable, the Deployment has been fully rolled out
+		// note: old pods or excess pods (scale-down) might still be terminating, but there is no way to tell this from the
+		// Deployment's status, see https://github.com/kubernetes/kubernetes/issues/110171
+		return false
+	}
+
+	return true
+}
+
+// GetDeploymentCondition returns the condition with the given type or nil, if it is not included.
+func GetDeploymentCondition(conditions []appsv1.DeploymentCondition, conditionType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for _, cond := range conditions {
+		if cond.Type == conditionType {
+			return &cond
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, the controller only waited for the latest generation to be observed and the minimum number of replicas to be available.
Now it also properly waits until the deployment has been fully rolled out.

This might cause the reconciliation latency to increase but it is semantically more correct.