### PR TITLE
Add `run_id` label to experiment metrics, add filter in dashboard

### DIFF
--- a/config/monitoring/sharder/sharder_servicemonitor.yaml
+++ b/config/monitoring/sharder/sharder_servicemonitor.yaml
@@ -16,6 +16,10 @@ spec:
     scrapeTimeout: 10s
     tlsConfig:
       insecureSkipVerify: true
+    relabelings:
+    - action: labelmap
+      regex: "__meta_kubernetes_pod_label_label_prometheus_io_(.*)"
+      replacement: "${1}"
   selector:
     matchLabels:
       app.kubernetes.io/name: controller-sharding

--- a/hack/config/monitoring/default/kustomization.yaml
+++ b/hack/config/monitoring/default/kustomization.yaml
@@ -56,3 +56,10 @@ patches:
     kind: Deployment
     name: kube-state-metrics
     namespace: monitoring
+- path: patch_kubestatemetrics_servicemonitor.yaml
+  target:
+    group: monitoring.coreos.com
+    version: v1
+    kind: ServiceMonitor
+    name: kube-state-metrics
+    namespace: monitoring

--- a/hack/config/monitoring/default/patch_kubestatemetrics.yaml
+++ b/hack/config/monitoring/default/patch_kubestatemetrics.yaml
@@ -3,3 +3,9 @@
   path: /spec/template/spec/containers/0/args/-
   value:
     --namespaces=cert-manager,default,experiment,external-dns,ingress-nginx,kube-node-lease,kube-public,kube-system,kyverno,monitoring,parca,sharding-system,webhosting-system
+# add run_id label to kube_pod_labels to select metrics by experiment run ID
+# flag doesn't support wildcard patterns
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --metric-labels-allowlist=pods=[label.prometheus.io/run_id]

--- a/hack/config/monitoring/default/patch_kubestatemetrics_servicemonitor.yaml
+++ b/hack/config/monitoring/default/patch_kubestatemetrics_servicemonitor.yaml
@@ -1,0 +1,12 @@
+# label map for label.prometheus.io/* labels
+- op: add
+  path: /spec/endpoints/0/metricRelabelings/-
+  value:
+    action: labelmap
+    regex: "label_label_prometheus_io_(.*)"
+    replacement: "${1}"
+- op: add
+  path: /spec/endpoints/0/metricRelabelings/-
+  value:
+    action: labeldrop
+    regex: "label_label_prometheus_io_(.*)"

--- a/hack/config/monitoring/default/patch_prometheus_resources.yaml
+++ b/hack/config/monitoring/default/patch_prometheus_resources.yaml
@@ -8,8 +8,8 @@ spec:
   alerting: null
   resources:
     requests:
-      cpu: 1000m
+      cpu: 3000m
       memory: 12Gi
     limits:
-      cpu: 3000m # replaying WAL takes some CPU
+      cpu: 4000m # replaying WAL takes some CPU
       memory: 12Gi

--- a/hack/config/skaffold.yaml
+++ b/hack/config/skaffold.yaml
@@ -147,6 +147,8 @@ kind: Config
 metadata:
   name: sharder
 build:
+  tagPolicy:
+    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/sharder
       ko:
@@ -189,6 +191,8 @@ kind: Config
 metadata:
   name: shard
 build:
+  tagPolicy:
+    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/shard
       ko:
@@ -277,6 +281,8 @@ kind: Config
 metadata:
   name: profiling
 build:
+  tagPolicy:
+    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/janitor
       ko:

--- a/webhosting-operator/config/experiment/base/job.yaml
+++ b/webhosting-operator/config/experiment/base/job.yaml
@@ -15,6 +15,10 @@ spec:
         args:
         - --zap-log-level=info
         env:
+        - name: RUN_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: DISABLE_HTTP2
           value: "true"
         ports:

--- a/webhosting-operator/config/experiment/base/rbac.yaml
+++ b/webhosting-operator/config/experiment/base/rbac.yaml
@@ -44,11 +44,14 @@ rules:
   - create
   - delete
 - apiGroups:
-  - ""
+  - apps
   resources:
-  - pods
+  - deployments
   verbs:
-  - deletecollection
+  - get
+  - list
+  - watch
+  - patch
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/webhosting-operator/config/monitoring/default/dashboards/experiments.json
+++ b/webhosting-operator/config/monitoring/default/dashboards/experiments.json
@@ -103,7 +103,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -117,8 +117,8 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "count(kube_website_info)",
-          "legendFormat": "website count",
+          "expr": "count(kube_website_info{run_id=~\"$run_id\"}) by (run_id)",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
@@ -216,7 +216,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(rate(\n    controller_runtime_reconcile_total{\n        job=\"experiment\", result!=\"error\",\n        controller=~\"website-(generator|deleter|mutator)\"\n    }[$__rate_interval]\n)) by (controller)",
+          "expr": "sum(\n    rate(controller_runtime_reconcile_total{\n        job=\"experiment\", result!=\"error\",\n        controller=~\"website-(generator|deleter|mutator)\"\n    }[$__rate_interval])\n    * on(namespace, pod) group_left\n    max by (namespace, pod, uid) (kube_pod_info{namespace=\"experiment\", pod=~\"experiment-.+\", uid=~\"$run_id\"})\n) by (controller)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -248,7 +248,7 @@
         "defaults": {
           "color": {
             "fixedColor": "text",
-            "mode": "fixed",
+            "mode": "palette-classic",
             "seriesBy": "last"
           },
           "custom": {
@@ -276,7 +276,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "dashed+area"
@@ -309,17 +309,15 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": false,
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
           "sortBy": "Last *",
           "sortDesc": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "desc"
         }
       },
@@ -330,7 +328,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n    sum by (name, le) (rate(\n        workqueue_queue_duration_seconds_bucket{\n            job=\"webhosting-operator\", name=\"website\"\n        }[$__rate_interval]\n    ))\n)",
+          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        workqueue_queue_duration_seconds_bucket{\n            job=\"webhosting-operator\", name=\"website\", run_id=~\"$run_id\"\n        }[$__rate_interval]\n    ))\n)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -349,7 +347,7 @@
         "defaults": {
           "color": {
             "fixedColor": "text",
-            "mode": "fixed",
+            "mode": "palette-classic",
             "seriesBy": "last"
           },
           "custom": {
@@ -377,7 +375,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "dashed+area"
@@ -410,17 +408,15 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": false,
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
           "sortBy": "Last *",
           "sortDesc": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "desc"
         }
       },
@@ -431,8 +427,8 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n    sum by (le) (rate(\n        experiment_website_reconciliation_duration_seconds_bucket{\n            job=\"experiment\"\n        }[$__rate_interval]\n    ))\n)",
-          "legendFormat": "website",
+          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        experiment_website_reconciliation_duration_seconds_bucket{\n            job=\"experiment\", run_id=~\"$run_id\"\n        }[$__rate_interval]\n    ))\n)",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
@@ -541,7 +537,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(\n    container_cpu_usage_seconds_total{\n        pod=~\"sharder-.+|webhosting-operator-.+\",\n        container=~\"sharder|manager\"\n    }[1m]\n))",
+          "expr": "sum by (namespace, pod) (rate(\n    container_cpu_usage_seconds_total{\n        pod=~\"sharder-.+|webhosting-operator-.+\",\n        container=~\"sharder|manager\"\n    }[1m]\n)) * on (namespace, pod) group_left (run_id) max by (namespace, pod, run_id) (kube_pod_labels{run_id=~\"$run_id\"})",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -636,7 +632,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (\n    go_memory_classes_total_bytes{pod=~\"sharder-.+|webhosting-operator-.+\"}\n    - go_memory_classes_heap_released_bytes{\n        pod=~\"sharder-.+|webhosting-operator-.+\"\n    }\n    - go_memory_classes_heap_unused_bytes{\n        pod=~\"sharder-.+|webhosting-operator-.+\"\n    }\n    - go_memory_classes_heap_free_bytes{\n        pod=~\"sharder-.+|webhosting-operator-.+\"\n    }\n)",
+          "expr": "sum by (namespace, pod, run_id) (\n    go_memory_classes_total_bytes{pod=~\"sharder-.+|webhosting-operator-.+\",run_id=~\"$run_id\"}\n    - go_memory_classes_heap_released_bytes{\n        pod=~\"sharder-.+|webhosting-operator-.+\",\n        run_id=~\"$run_id\"\n    }\n    - go_memory_classes_heap_unused_bytes{\n        pod=~\"sharder-.+|webhosting-operator-.+\",\n        run_id=~\"$run_id\"\n    }\n    - go_memory_classes_heap_free_bytes{\n        pod=~\"sharder-.+|webhosting-operator-.+\",\n        run_id=~\"$run_id\"\n    }\n)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -731,7 +727,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(\n    container_network_receive_bytes_total{\n        pod=~\"sharder-.+|webhosting-operator-.+\"\n    }[1m]\n))",
+          "expr": "sum by (namespace, pod, run_id) (rate(\n    container_network_receive_bytes_total{\n        pod=~\"sharder-.+|webhosting-operator-.+\"\n    }[1m]\n)) * on (namespace, pod) group_left (run_id) max by (namespace, pod, run_id) (kube_pod_labels{run_id=~\"$run_id\"})",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -826,7 +822,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace, pod) (rate(\n    container_network_transmit_bytes_total{\n        pod=~\"sharder-.+|webhosting-operator-.+\"\n    }[1m]\n))",
+          "expr": "sum by (namespace, pod, run_id) (rate(\n    container_network_transmit_bytes_total{\n        pod=~\"sharder-.+|webhosting-operator-.+\"\n    }[1m]\n)) * on (namespace, pod) group_left (run_id) max by (namespace, pod, run_id) (kube_pod_labels{run_id=~\"$run_id\"})",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -841,7 +837,39 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P1809F7CD0C75ACF3"
+        },
+        "definition": "label_values(kube_pod_info{namespace=\"experiment\", pod=~\"experiment-.+\"},uid)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "run_id",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info{namespace=\"experiment\", pod=~\"experiment-.+\"},uid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",
@@ -851,6 +879,6 @@
   "timezone": "",
   "title": "Experiments",
   "uid": "d33509b4-7e28-41e2-961a-4d7fbad57d01",
-  "version": 7,
+  "version": 2,
   "weekStart": ""
 }

--- a/webhosting-operator/config/monitoring/default/dashboards/experiments.json
+++ b/webhosting-operator/config/monitoring/default/dashboards/experiments.json
@@ -117,7 +117,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "count(kube_website_info{run_id=~\"$run_id\"}) by (run_id)",
+          "expr": "sum(namespace_run:kube_website_info:sum{run_id=~\"$run_id\"}) by (run_id)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/webhosting-operator/config/monitoring/default/dashboards/webhosting.json
+++ b/webhosting-operator/config/monitoring/default/dashboards/webhosting.json
@@ -90,7 +90,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -165,7 +165,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -234,7 +234,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -300,7 +300,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -630,6 +630,21 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Terminating"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -850,7 +865,9 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
           "links": [],
@@ -906,7 +923,9 @@
       },
       "id": 19,
       "options": {
+        "cellHeight": "sm",
         "footer": {
+          "countRows": false,
           "fields": "",
           "reducer": [
             "sum"
@@ -915,7 +934,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -957,7 +976,7 @@
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [
     "webhosting-operator"

--- a/webhosting-operator/config/monitoring/default/dashboards/webhosting.json
+++ b/webhosting-operator/config/monitoring/default/dashboards/webhosting.json
@@ -97,10 +97,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kube_website_info{namespace=~\"$project\"}) or vector(0)",
+          "expr": "sum(namespace_run:kube_website_info:sum{namespace=~\"$project\"}) or vector(0)",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -174,7 +176,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(sum(kube_website_status_phase{namespace=~\"$project\",phase=\"Ready\"}) or vector(0)) / (sum(kube_website_status_phase{namespace=~\"$project\"}) or vector(0)) * 100",
+          "expr": "(sum(namespace_phase:kube_website_status_phase:sum{namespace=~\"$project\",phase=\"Ready\"}) or vector(0)) / (sum(namespace_phase:kube_website_status_phase:sum{namespace=~\"$project\"}) or vector(0)) * 100",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -241,10 +243,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
           "expr": "sum(max(kube_theme_info) without (instance, pod)) or vector(0)",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -307,10 +311,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
           "expr": "sum(kube_namespace_status_phase{namespace=~\"project-.+\"}) or vector(0)",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -368,7 +374,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "normal"
@@ -422,10 +428,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kube_website_info{namespace=~\"$project\"} or 0*sum(kube_namespace_status_phase{namespace=~\"$project\"}) by (namespace)) by (namespace)",
+          "expr": "sum(namespace_run:kube_website_info:sum{namespace=~\"$project\"} or 0*sum(kube_namespace_status_phase{namespace=~\"$project\"}) by (namespace)) by (namespace)",
           "interval": "",
           "legendFormat": "{{namespace}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -466,7 +474,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "normal"
@@ -520,10 +528,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(max(kube_website_info{namespace=~\"$project\"}) without (instance, pod) or 0*max(kube_theme_info{}) by (theme)) by (theme)",
+          "expr": "sum(sum(namespace_theme:kube_website_info:sum{namespace=~\"$project\"}) by (theme) or 0*max(kube_theme_info{}) by (theme)) by (theme)",
           "interval": "",
           "legendFormat": "{{namespace}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -675,164 +685,16 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kube_website_status_phase{namespace=~\"$project\"}) by (phase)",
+          "expr": "sum(namespace_phase:kube_website_info:sum{namespace=~\"$project\"}) by (phase)",
           "interval": "",
           "legendFormat": "{{phase}}",
+          "range": true,
           "refId": "A"
         }
       ],
       "title": "Websites per Phase",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 100,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Error"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Ready"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Pending"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 15
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "exemplar": true,
-          "expr": "(sum(kube_website_info{namespace=~\"$project\"} unless on(uid) kube_website_info{namespace=~\"$project\"} offset $__rate_interval) and min(up{job=\"webhosting-operator\"} offset $__rate_interval) == 1) or vector(0)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Creation",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "exemplar": true,
-          "expr": "-(sum(kube_website_info{namespace=~\"$project\"} offset $__rate_interval unless on(uid) kube_website_info{namespace=~\"$project\"}) and min(up{job=\"webhosting-operator\"}) == 1) or vector(0)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Deletion",
-          "refId": "B"
-        }
-      ],
-      "title": "Website Churn Rate",
       "type": "timeseries"
     },
     {
@@ -941,8 +803,9 @@
             "type": "prometheus",
             "uid": "P1809F7CD0C75ACF3"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kube_website_info{namespace=~\"$project\"} * on(theme) group_left(color, font_family) max(kube_theme_info) without (instance, pod)) by (namespace, theme, website, color, font_family)",
+          "expr": "sum(kube_website_info{namespace=~\"$project\", website!~\"experiment-.+\"} * on(theme) group_left(color, font_family) max(kube_theme_info) without (instance, pod)) by (namespace, theme, website, color, font_family)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -1034,7 +897,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},

--- a/webhosting-operator/config/monitoring/webhosting-operator/kustomization.yaml
+++ b/webhosting-operator/config/monitoring/webhosting-operator/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 # "webhosting-system"
 - prometheus_rbac.yaml
 - servicemonitor.yaml
+- prometheusrule.yaml

--- a/webhosting-operator/config/monitoring/webhosting-operator/prometheusrule.yaml
+++ b/webhosting-operator/config/monitoring/webhosting-operator/prometheusrule.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: webhosting-operator
+spec:
+  groups:
+  - name: webhosting-website.rules
+    rules:
+    - record: namespace_run:kube_website_info:sum
+      expr: sum by (namespace, run_id) (kube_website_info)
+    - record: namespace_theme:kube_website_info:sum
+      expr: sum by (namespace, theme) (kube_website_info)
+    - record: namespace_phase:kube_website_status_phase:sum
+      expr: sum by (namespace, phase) (kube_website_status_phase)

--- a/webhosting-operator/config/monitoring/webhosting-operator/servicemonitor.yaml
+++ b/webhosting-operator/config/monitoring/webhosting-operator/servicemonitor.yaml
@@ -13,6 +13,10 @@ spec:
     scrapeTimeout: 10s
     tlsConfig:
       insecureSkipVerify: true
+    relabelings:
+    - action: labelmap
+      regex: "__meta_kubernetes_pod_label_label_prometheus_io_(.*)"
+      replacement: "${1}"
   jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:

--- a/webhosting-operator/pkg/experiment/scenario/base/base.go
+++ b/webhosting-operator/pkg/experiment/scenario/base/base.go
@@ -126,7 +126,9 @@ func (s *Scenario) Start(ctx context.Context) (err error) {
 	case <-time.After(30 * time.Second):
 	}
 
-	websiteTracker := &tracker.WebsiteTracker{}
+	websiteTracker := &tracker.WebsiteTracker{
+		RunID: s.RunID,
+	}
 	if err := websiteTracker.AddToManager(s.Manager); err != nil {
 		return fmt.Errorf("error adding website-tracker: %w", err)
 	}

--- a/webhosting-operator/skaffold.yaml
+++ b/webhosting-operator/skaffold.yaml
@@ -24,6 +24,8 @@ kind: Config
 metadata:
   name: webhosting-operator
 build:
+  tagPolicy:
+    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/webhosting-operator
       ko:
@@ -104,6 +106,8 @@ profiles:
     activation:
       - env: EXPERIMENT_SCENARIO=.+
     build:
+      tagPolicy:
+        inputDigest: {}
       artifacts:
         - image: ghcr.io/timebertt/kubernetes-controller-sharding/experiment
           ko:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes sure, all metrics related to experiments can be selected based on a `run_id` label (either directly or by joining with `kube_pod_info`).
The experiment's pod uid is used as the run ID now.
It is added to all observed pods before starting the experiment, which also rolls out the components to ensure a fresh state.
This allows selecting results in the experiments dashboard using the `run_id` filter. 

This is important for calculating sliding SLIs on the dashboard: the calculations use `$__rate_interval` on a range query instead of using the actual `15m` experiment time window on an instant query.
I.e., without the `run_id` filter, one would get deceptive SLIs when running multiple experiments in quick succession.

Also, prometheus is granted more resources, and recording rules for websites are used to increase the performance of the webhosting and experiments dashboard without killing prometheus for larger ranges.