### PR TITLE
Revert "Switch to `inputDigest` tagger"

### DIFF
--- a/hack/config/skaffold.yaml
+++ b/hack/config/skaffold.yaml
@@ -147,8 +147,6 @@ kind: Config
 metadata:
   name: sharder
 build:
-  tagPolicy:
-    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/sharder
       ko:
@@ -191,8 +189,6 @@ kind: Config
 metadata:
   name: shard
 build:
-  tagPolicy:
-    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/shard
       ko:
@@ -281,8 +277,6 @@ kind: Config
 metadata:
   name: profiling
 build:
-  tagPolicy:
-    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/janitor
       ko:

--- a/webhosting-operator/skaffold.yaml
+++ b/webhosting-operator/skaffold.yaml
@@ -24,8 +24,6 @@ kind: Config
 metadata:
   name: webhosting-operator
 build:
-  tagPolicy:
-    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/webhosting-operator
       ko:
@@ -106,8 +104,6 @@ profiles:
     activation:
       - env: EXPERIMENT_SCENARIO=.+
     build:
-      tagPolicy:
-        inputDigest: {}
       artifacts:
         - image: ghcr.io/timebertt/kubernetes-controller-sharding/experiment
           ko:


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit c0c1ba47e3e6663214a88fd6c97982b974e45c05.

It seems we can go back to the default tagger with skaffold [v2.10.1](https://github.com/GoogleContainerTools/skaffold/releases/tag/v2.10.1), see https://github.com/GoogleContainerTools/skaffold/pull/9301 and https://github.com/GoogleContainerTools/skaffold/pull/9278
