### PR TITLE
Switch to `github-releases` datasource for manually configured depedencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,7 +24,7 @@
       customType: "regex",
       fileMatch: ["kustomization\\.yaml$"],
       matchStrings: ["https:\/\/raw.githubusercontent.com\/(?<depName>.*?/.*?)\/(?<currentValue>.*?)\/"],
-      datasourceTemplate: "github-tags"
+      datasourceTemplate: "github-releases"
     },
     {
       // update `_VERSION` variables in Makefiles and scripts
@@ -80,7 +80,7 @@
         // datasource=go
         "k8s.io/", // includes more than the k8s-go group! (e.g., k8s.io/utils)
         "sigs.k8s.io/controller-runtime",
-        // datasource=github-tags
+        // datasource=github-releases
         "kubernetes/kubernetes",
         "kubernetes-sigs/controller-tools"
       ],
@@ -92,7 +92,7 @@
         // datasource=go
         "k8s.io/", // includes more than the k8s-go group! (e.g., k8s.io/utils)
         "sigs.k8s.io/controller-runtime",
-        // datasource=github-tags
+        // datasource=github-releases
         "kubernetes/kubernetes",
         "kubernetes-sigs/controller-tools"
       ],
@@ -140,13 +140,13 @@
     },
     {
       // special case for ingress-nginx: version is prefixed with `controller-`
-      matchDatasources: ["github-tags"],
+      matchDatasources: ["github-releases"],
       matchPackageNames: ["kubernetes/ingress-nginx"],
       "versionCompatibility": "^(?<compatibility>.*)-(?<version>.+)$"
     },
     {
       // manual action required: upgrading kube-prometheus is not fully automated yet
-      matchDatasources: ["github-tags"],
+      matchDatasources: ["github-releases"],
       matchPackageNames: ["prometheus-operator/kube-prometheus"],
       prHeader: "⚠️ Manual action required ⚠️\nPlease check this PR out and run `hack/config/monitoring/update.sh`."
     },

--- a/.github/workflows/controller-sharding.yaml
+++ b/.github/workflows/controller-sharding.yaml
@@ -41,7 +41,7 @@ jobs:
   images:
     runs-on: ubuntu-latest
     env:
-      # renovate: datasource=github-tags depName=ko-build/ko
+      # renovate: datasource=github-releases depName=ko-build/ko
       KO_VERSION: v0.15.1
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/webhosting-operator.yaml
+++ b/.github/workflows/webhosting-operator.yaml
@@ -41,7 +41,7 @@ jobs:
   images:
     runs-on: ubuntu-latest
     env:
-      # renovate: datasource=github-tags depName=ko-build/ko
+      # renovate: datasource=github-releases depName=ko-build/ko
       KO_VERSION: v0.15.1
     steps:
     - uses: actions/checkout@v4

--- a/hack/config/monitoring/update.sh
+++ b/hack/config/monitoring/update.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# renovate: datasource=github-tags depName=prometheus-operator/kube-prometheus
+# renovate: datasource=github-releases depName=prometheus-operator/kube-prometheus
 KUBE_PROMETHEUS_VERSION=v0.13.0
 echo "> Fetching kube-prometheus@$KUBE_PROMETHEUS_VERSION"
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -18,39 +18,39 @@ $(TOOLS_BIN_DIR)/.version_%:
 	@touch $@
 
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
-# renovate: datasource=github-tags depName=kubernetes-sigs/controller-tools
+# renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 CONTROLLER_GEN_VERSION ?= v0.14.0
 $(CONTROLLER_GEN): $(call tool_version_file,$(CONTROLLER_GEN),$(CONTROLLER_GEN_VERSION))
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
-# renovate: datasource=github-tags depName=golangci/golangci-lint
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.56.1
 $(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERSION))
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_VERSION)
 
 KIND := $(TOOLS_BIN_DIR)/kind
-# renovate: datasource=github-tags depName=kubernetes-sigs/kind
+# renovate: datasource=github-releases depName=kubernetes-sigs/kind
 KIND_VERSION ?= v0.21.0
 $(KIND): $(call tool_version_file,$(KIND),$(KIND_VERSION))
 	curl -Lo $(KIND) https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 	chmod +x $(KIND)
 
 KO := $(TOOLS_BIN_DIR)/ko
-# renovate: datasource=github-tags depName=ko-build/ko
+# renovate: datasource=github-releases depName=ko-build/ko
 KO_VERSION ?= v0.15.1
 $(KO): $(call tool_version_file,$(KO),$(KO_VERSION))
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/google/ko@$(KO_VERSION)
 
 KUBECTL := $(TOOLS_BIN_DIR)/kubectl
-# renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubernetes
+# renovate: datasource=github-releases depName=kubectl packageName=kubernetes/kubernetes
 KUBECTL_VERSION ?= v1.29.1
 $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
 	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(shell uname -s | tr '[:upper:]' '[:lower:]')/$(shell uname -m | sed 's/x86_64/amd64/')/kubectl
 	chmod +x $(KUBECTL)
 
 KYVERNO := $(TOOLS_BIN_DIR)/kyverno
-# renovate: datasource=github-tags depName=kyverno/kyverno
+# renovate: datasource=github-releases depName=kyverno/kyverno
 KYVERNO_VERSION ?= v1.10.7
 $(KYVERNO): $(call tool_version_file,$(KYVERNO),$(KYVERNO_VERSION))
 	curl -Lo - https://github.com/kyverno/kyverno/releases/download/$(KYVERNO_VERSION)/kyverno-cli_$(KYVERNO_VERSION)_$(shell uname -s | tr '[:upper:]' '[:lower:]')_$(shell uname -m | sed 's/aarch64/arm64/').tar.gz | tar -xzmf - -C $(TOOLS_BIN_DIR) kyverno
@@ -61,14 +61,14 @@ $(SETUP_ENVTEST): go.mod
 	go build -o $(SETUP_ENVTEST) sigs.k8s.io/controller-runtime/tools/setup-envtest
 
 SKAFFOLD := $(TOOLS_BIN_DIR)/skaffold
-# renovate: datasource=github-tags depName=GoogleContainerTools/skaffold
+# renovate: datasource=github-releases depName=GoogleContainerTools/skaffold
 SKAFFOLD_VERSION ?= v2.10.1
 $(SKAFFOLD): $(call tool_version_file,$(SKAFFOLD),$(SKAFFOLD_VERSION))
 	curl -Lo $(SKAFFOLD) https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/')
 	chmod +x $(SKAFFOLD)
 
 YQ := $(TOOLS_BIN_DIR)/yq
-# renovate: datasource=github-tags depName=mikefarah/yq
+# renovate: datasource=github-releases depName=mikefarah/yq
 YQ_VERSION ?= v4.40.7
 $(YQ): $(call tool_version_file,$(YQ),$(YQ_VERSION))
 	curl -Lo $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(shell uname -s | tr '[:upper:]' '[:lower:]')_$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')

--- a/webhosting-operator/tools.mk
+++ b/webhosting-operator/tools.mk
@@ -18,26 +18,26 @@ $(TOOLS_BIN_DIR)/.version_%:
 	@touch $@
 
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
-# renovate: datasource=github-tags depName=kubernetes-sigs/controller-tools
+# renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 CONTROLLER_GEN_VERSION ?= v0.14.0
 $(CONTROLLER_GEN): $(call tool_version_file,$(CONTROLLER_GEN),$(CONTROLLER_GEN_VERSION))
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
 KIND := $(TOOLS_BIN_DIR)/kind
-# renovate: datasource=github-tags depName=kubernetes-sigs/kind
+# renovate: datasource=github-releases depName=kubernetes-sigs/kind
 KIND_VERSION ?= v0.21.0
 $(KIND): $(call tool_version_file,$(KIND),$(KIND_VERSION))
 	curl -Lo $(KIND) https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 	chmod +x $(KIND)
 
 KO := $(TOOLS_BIN_DIR)/ko
-# renovate: datasource=github-tags depName=ko-build/ko
+# renovate: datasource=github-releases depName=ko-build/ko
 KO_VERSION ?= v0.15.1
 $(KO): $(call tool_version_file,$(KO),$(KO_VERSION))
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/google/ko@$(KO_VERSION)
 
 KUBECTL := $(TOOLS_BIN_DIR)/kubectl
-# renovate: datasource=github-tags depName=kubectl packageName=kubernetes/kubernetes
+# renovate: datasource=github-releases depName=kubectl packageName=kubernetes/kubernetes
 KUBECTL_VERSION ?= v1.29.1
 $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
 	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(shell uname -s | tr '[:upper:]' '[:lower:]')/$(shell uname -m | sed 's/x86_64/amd64/')/kubectl
@@ -48,14 +48,14 @@ $(SETUP_ENVTEST): go.mod
 	go build -o $(SETUP_ENVTEST) sigs.k8s.io/controller-runtime/tools/setup-envtest
 
 SKAFFOLD := $(TOOLS_BIN_DIR)/skaffold
-# renovate: datasource=github-tags depName=GoogleContainerTools/skaffold
+# renovate: datasource=github-releases depName=GoogleContainerTools/skaffold
 SKAFFOLD_VERSION ?= v2.10.1
 $(SKAFFOLD): $(call tool_version_file,$(SKAFFOLD),$(SKAFFOLD_VERSION))
 	curl -Lo $(SKAFFOLD) https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/')
 	chmod +x $(SKAFFOLD)
 
 YQ := $(TOOLS_BIN_DIR)/yq
-# renovate: datasource=github-tags depName=mikefarah/yq
+# renovate: datasource=github-releases depName=mikefarah/yq
 YQ_VERSION ?= v4.40.7
 $(YQ): $(call tool_version_file,$(YQ),$(YQ_VERSION))
 	curl -Lo $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(shell uname -s | tr '[:upper:]' '[:lower:]')_$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes, the `github-tags` datasource seems to result in update PRs without proper release notes, as the tag is probably pushed before the release is created (racy?), e.g., https://github.com/timebertt/kubernetes-controller-sharding/pull/142.
Switch to `github-releases` for manually configured dependencies to get release notes in PRs.