### PR TITLE
Reapply "Switch to `inputDigest` tagger"

### DIFF
--- a/hack/config/skaffold.yaml
+++ b/hack/config/skaffold.yaml
@@ -147,6 +147,8 @@ kind: Config
 metadata:
   name: sharder
 build:
+  tagPolicy:
+    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/sharder
       ko:
@@ -189,6 +191,8 @@ kind: Config
 metadata:
   name: shard
 build:
+  tagPolicy:
+    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/shard
       ko:
@@ -277,6 +281,8 @@ kind: Config
 metadata:
   name: profiling
 build:
+  tagPolicy:
+    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/janitor
       ko:

--- a/webhosting-operator/skaffold.yaml
+++ b/webhosting-operator/skaffold.yaml
@@ -24,6 +24,8 @@ kind: Config
 metadata:
   name: webhosting-operator
 build:
+  tagPolicy:
+    inputDigest: {}
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/webhosting-operator
       ko:
@@ -104,6 +106,8 @@ profiles:
     activation:
       - env: EXPERIMENT_SCENARIO=.+
     build:
+      tagPolicy:
+        inputDigest: {}
       artifacts:
         - image: ghcr.io/timebertt/kubernetes-controller-sharding/experiment
           ko:


### PR DESCRIPTION
Reverts timebertt/kubernetes-controller-sharding#136

It seems skaffold [v2.10.1](https://github.com/GoogleContainerTools/skaffold/releases/tag/v2.10.1) didn't solve the problem where it doesn't rebuild images although sources have changed (ref https://github.com/GoogleContainerTools/skaffold/issues/9248).

Using the `inputDigest` tagger doesn't seem like a bad option after all anyway, so let's keep it.