### PR TITLE
Use `vgopath` for `code-generator`

### DIFF
--- a/.github/workflows/controller-sharding.yaml
+++ b/.github/workflows/controller-sharding.yaml
@@ -19,22 +19,11 @@ jobs:
   verify:
     runs-on: ubuntu-latest
 
-    # update-codegen requires the workspace to be placed in GOPATH.
-    # Set up env var, working directory, and check out at the correct path in GOPATH.
-    env:
-      GOPATH: /home/runner/work/kubernetes-controller-sharding/kubernetes-controller-sharding/go
-    defaults:
-      run:
-        working-directory: go/src/github.com/timebertt/kubernetes-controller-sharding
-
     steps:
     - uses: actions/checkout@v4
-      with:
-        path: go/src/github.com/timebertt/kubernetes-controller-sharding
     - uses: actions/setup-go@v5
       with:
-        go-version-file: go/src/github.com/timebertt/kubernetes-controller-sharding/go.mod
-        cache-dependency-path: go/src/github.com/timebertt/kubernetes-controller-sharding/go.sum
+        go-version-file: go.mod
     - name: Verify
       run: make verify
 

--- a/.github/workflows/webhosting-operator.yaml
+++ b/.github/workflows/webhosting-operator.yaml
@@ -19,22 +19,12 @@ jobs:
   verify:
     runs-on: ubuntu-latest
 
-    # update-codegen requires the workspace to be placed in GOPATH.
-    # Set up env var, working directory, and check out at the correct path in GOPATH.
-    env:
-      GOPATH: /home/runner/work/kubernetes-controller-sharding/kubernetes-controller-sharding/go
-    defaults:
-      run:
-        working-directory: go/src/github.com/timebertt/kubernetes-controller-sharding
-
     steps:
     - uses: actions/checkout@v4
-      with:
-        path: go/src/github.com/timebertt/kubernetes-controller-sharding
     - uses: actions/setup-go@v5
       with:
-        go-version-file: go/src/github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/go.mod
-        cache-dependency-path: go/src/github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/go.sum
+        go-version-file: webhosting-operator/go.mod
+        cache-dependency-path: webhosting-operator/go.sum
     - name: Verify
       run: make -C webhosting-operator verify
 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ generate-fast: $(CONTROLLER_GEN) modules ## Run all fast code generators
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./pkg/..."
 
 .PHONY: generate
-generate: generate-fast modules ## Run all code generators
+generate: $(VGOPATH) generate-fast modules ## Run all code generators
 	hack/update-codegen.sh
 
 .PHONY: fmt

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -67,6 +67,12 @@ $(SKAFFOLD): $(call tool_version_file,$(SKAFFOLD),$(SKAFFOLD_VERSION))
 	curl -Lo $(SKAFFOLD) https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/')
 	chmod +x $(SKAFFOLD)
 
+VGOPATH := $(TOOLS_BIN_DIR)/vgopath
+# renovate: datasource=github-releases depName=ironcore-dev/vgopath
+VGOPATH_VERSION ?= v0.1.4
+$(VGOPATH): $(call tool_version_file,$(VGOPATH),$(VGOPATH_VERSION))
+	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/ironcore-dev/vgopath@$(VGOPATH_VERSION)
+
 YQ := $(TOOLS_BIN_DIR)/yq
 # renovate: datasource=github-releases depName=mikefarah/yq
 YQ_VERSION ?= v4.41.1

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -17,21 +17,18 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Friendly reminder if workspace location is not in $GOPATH
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-if [ "${SCRIPT_DIR}" != "$(realpath $GOPATH)/src/github.com/timebertt/kubernetes-controller-sharding/hack" ]; then
-  cat <<EOF
-hack/update-codegen.sh does not work correctly if your workspace is outside GOPATH
-because of a know bug in k8s.io/code-generator, see https://github.com/kubernetes/kubernetes/issues/86753.
-Please move the workspace to $(realpath $GOPATH)/src/github.com/timebertt/kubernetes-controller-sharding.
-EOF
-  exit 1
-fi
 
 # fetch code-generator module to execute the scripts from the modcache (we don't vendor here)
 CODE_GENERATOR_DIR="$(go list -m -tags tools -f '{{ .Dir }}' k8s.io/code-generator)"
 
-rm -f ${GOPATH}/bin/*-gen
+# setup virtual GOPATH
+# k8s.io/code-generator does not work outside GOPATH, see https://github.com/kubernetes/kubernetes/issues/86753.
+source "$SCRIPT_DIR"/vgopath-setup.sh
+
+# We need to explicitly pass GO111MODULE=off to k8s.io/code-generator as it is significantly slower otherwise,
+# see https://github.com/kubernetes/code-generator/issues/100.
+export GO111MODULE=off
 
 # config API
 
@@ -42,7 +39,7 @@ config_group() {
 
   kube::codegen::gen_helpers \
       --input-pkg-root github.com/timebertt/kubernetes-controller-sharding/pkg/apis \
-      --output-base "${SCRIPT_DIR}/../../../.." \
+      --output-base "${GOPATH}/src" \
       --boilerplate "${SCRIPT_DIR}/boilerplate.go.txt"
 }
 

--- a/hack/vgopath-setup.sh
+++ b/hack/vgopath-setup.sh
@@ -1,0 +1,13 @@
+# Ensure that if GOPATH is set, the GOPATH/{bin,pkg} directory exists. This might not be the case in CI.
+# As we will create a symlink against the bin folder we need to make sure that the bin directory is
+# present in the GOPATH.
+if [ -n "${GOPATH:-}" ] && [ ! -d "$GOPATH/bin" ]; then mkdir -p "$GOPATH/bin"; fi
+if [ -n "${GOPATH:-}" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
+
+VIRTUAL_GOPATH="$(mktemp -d)"
+trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
+
+# Setup virtual GOPATH
+go mod download && vgopath -o "$VIRTUAL_GOPATH"
+
+export GOPATH="$VIRTUAL_GOPATH"

--- a/webhosting-operator/Makefile
+++ b/webhosting-operator/Makefile
@@ -49,7 +49,7 @@ manifests: $(CONTROLLER_GEN) ## Generate WebhookConfiguration, ClusterRole and C
 	$(CONTROLLER_GEN) rbac:roleName=operator crd paths="./..." output:rbac:artifacts:config=config/manager/rbac output:crd:artifacts:config=config/manager/crds
 
 .PHONY: generate
-generate: $(CONTROLLER_GEN) modules ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: $(CONTROLLER_GEN) $(VGOPATH) modules ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="../hack/boilerplate.go.txt" paths="./..."
 	hack/update-codegen.sh
 

--- a/webhosting-operator/tools.mk
+++ b/webhosting-operator/tools.mk
@@ -54,6 +54,12 @@ $(SKAFFOLD): $(call tool_version_file,$(SKAFFOLD),$(SKAFFOLD_VERSION))
 	curl -Lo $(SKAFFOLD) https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/')
 	chmod +x $(SKAFFOLD)
 
+VGOPATH := $(TOOLS_BIN_DIR)/vgopath
+# renovate: datasource=github-releases depName=ironcore-dev/vgopath
+VGOPATH_VERSION ?= v0.1.4
+$(VGOPATH): $(call tool_version_file,$(VGOPATH),$(VGOPATH_VERSION))
+	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/ironcore-dev/vgopath@$(VGOPATH_VERSION)
+
 YQ := $(TOOLS_BIN_DIR)/yq
 # renovate: datasource=github-releases depName=mikefarah/yq
 YQ_VERSION ?= v4.41.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `vgopath` to trick `code-generator` into thinking it was inside a `GOPATH` file tree.
This allows running `make generate` when cloning the repository outside of `GOPATH`, e.g., in GitHub actions.

Also, set `GO111MODULE=off` to significantly speed up code-generator.