### PR TITLE
Automerge more dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,8 @@
   extends: [
     "config:recommended",
     ":semanticCommitsDisabled",
+    ":automergeStableNonMajor",
+    ":automergePatch",
     "regexManagers:githubActionsVersions"
   ],
   labels: ["dependencies"],
@@ -37,6 +39,12 @@
     }
   ],
   packageRules: [
+    {
+      // disable automerge for go minor updates
+      matchDatasources: ["golang-version"],
+      matchUpdateTypes: ["minor"],
+      automerge: false
+    },
     {
       // bump k8s and controller-runtime go dependencies together
       groupName: "k8s packages",
@@ -75,7 +83,7 @@
       ]
     },
     {
-      // separate k8s patch updates (keep in sync with the next package rule)
+      // disable automerge for k8s minor updates
       matchPackagePrefixes: [
         // datasource=go
         "k8s.io/", // includes more than the k8s-go group! (e.g., k8s.io/utils)
@@ -84,19 +92,14 @@
         "kubernetes/kubernetes",
         "kubernetes-sigs/controller-tools"
       ],
-      separateMinorPatch: true
+      matchUpdateTypes: ["minor"],
+      automerge: false
     },
     {
-      // automerge k8s patch updates (keep in sync with the previous package rule)
-      matchPackagePrefixes: [
-        // datasource=go
-        "k8s.io/", // includes more than the k8s-go group! (e.g., k8s.io/utils)
-        "sigs.k8s.io/controller-runtime",
-        // datasource=github-releases
-        "kubernetes/kubernetes",
-        "kubernetes-sigs/controller-tools"
-      ],
-      matchUpdateTypes: ["patch", "digest"],
+      // automerge k8s.io/utils updates
+      matchDatasources: ["go"],
+      matchPackageNames: ["k8s.io/utils"],
+      matchUpdateTypes: ["digest"],
       automerge: true
     },
     {


### PR DESCRIPTION
**What this PR does / why we need it**:

Automate more dependency updates:
- automerge minor updates for >= v1.0.0 (except go version and k8s version/packages)
- automerge all patch updates