### PR TITLE
Improve automerge settings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,13 +3,13 @@
   extends: [
     "config:recommended",
     ":semanticCommitsDisabled",
-    ":automergeStableNonMajor",
-    ":automergePatch",
     "regexManagers:githubActionsVersions"
   ],
   labels: ["dependencies"],
   postUpdateOptions: ["gomodTidy"],
   automergeStrategy: "squash",
+  // required for automerging patch updates
+  separateMinorPatch: true,
   kubernetes: {
     fileMatch: ["\\.yaml$"]
   },
@@ -39,6 +39,18 @@
     }
   ],
   packageRules: [
+    {
+      // automerge non-major updates except 0.* versions
+      // similar to :automergeStableNonMajor preset, but also works for versioning schemes without range support
+      matchUpdateTypes: ["minor", "patch"],
+      matchCurrentVersion: "!/^v?0\\./",
+      automerge: true
+    },
+    {
+      // automerge patch updates
+      matchUpdateTypes: ["patch"],
+      automerge: true
+    },
     {
       // disable automerge for go minor updates
       matchDatasources: ["golang-version"],


### PR DESCRIPTION
**What this PR does / why we need it**:

Automerging should also work for versioning schemes without range support now (e.g., for tools from `github-releases` datasource). 
Replace preset for automerging patches to make things more explicit and easier to understand.
