### PR TITLE
Disable renovate for main module dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,11 @@
   ],
   packageRules: [
     {
+      // disable update of dependency on the main module
+      matchPackageNames: ["github.com/timebertt/kubernetes-controller-sharding"],
+      enabled: false
+    },
+    {
       // automerge non-major updates except 0.* versions
       // similar to :automergeStableNonMajor preset, but also works for versioning schemes without range support
       matchUpdateTypes: ["minor", "patch"],


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable renovate for main module dependency to skip unneeded PRs like https://github.com/timebertt/kubernetes-controller-sharding/pull/232.