### PR TITLE
Lint webhosting-operator module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ generate: $(VGOPATH) generate-fast generate-fast-webhosting modules ## Run all c
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...
+	cd webhosting-operator && go fmt ./...
 
 .PHONY: test
 test: $(SETUP_ENVTEST) ## Run tests.
@@ -94,7 +95,7 @@ skaffold-fix: $(SKAFFOLD) ## Upgrade skaffold configuration to the latest apiVer
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run golangci-lint against code.
-	$(GOLANGCI_LINT) run ./...
+	$(GOLANGCI_LINT) run ./... ./webhosting-operator/...
 
 .PHONY: check
 check: lint test test-kyverno ## Check everything (lint + test + test-kyverno).

--- a/webhosting-operator/cmd/experiment/main.go
+++ b/webhosting-operator/cmd/experiment/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"math/rand"
 	"os"
 	"time"
 
@@ -32,7 +31,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -63,8 +62,6 @@ func init() {
 }
 
 func main() {
-	rand.Seed(time.Now().Unix())
-
 	zapOpts := zap.Options{
 		Development: true,
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
@@ -111,7 +108,7 @@ func main() {
 				LeaderElection: false,
 
 				Controller: config.Controller{
-					RecoverPanic: pointer.Bool(true),
+					RecoverPanic: ptr.To(true),
 				},
 			})
 			if err != nil {

--- a/webhosting-operator/cmd/measure/main.go
+++ b/webhosting-operator/cmd/measure/main.go
@@ -207,11 +207,11 @@ func run(ctx context.Context, c v1.API) error {
 	}
 
 	if slosChecked {
-		if slosMet {
-			fmt.Println("✅ SLO verifications succeeded")
-		} else {
+		if !slosMet {
 			return fmt.Errorf("❌ SLO verifications failed")
 		}
+
+		fmt.Println("✅ SLO verifications succeeded")
 	} else {
 		fmt.Println("ℹ️ No SLOs defined")
 	}
@@ -347,7 +347,7 @@ func (q Query) writeResult(data metricData) error {
 		return err
 	}
 
-	fmt.Printf("Succesfully written output to %s\n", fileName)
+	fmt.Printf("Successfully written output to %s\n", fileName)
 	return nil
 }
 

--- a/webhosting-operator/cmd/samples-generator/main.go
+++ b/webhosting-operator/cmd/samples-generator/main.go
@@ -83,7 +83,7 @@ func generateSamples(ctx context.Context, c client.Client) error {
 		return err
 	}
 
-	var themes []string
+	themes := make([]string, 0, len(themeList.Items))
 	for _, theme := range themeList.Items {
 		themes = append(themes, theme.Name)
 	}
@@ -104,6 +104,7 @@ func generateSamples(ctx context.Context, c client.Client) error {
 	for _, namespace := range namespaceList.Items {
 		project := namespace.Name
 
+		// nolint:gosec // doesn't need to be cryptographically secure
 		websiteCount := rand.Intn(50) + 1
 		if count > 0 {
 			websiteCount = count

--- a/webhosting-operator/pkg/apis/config/v1alpha1/defaults.go
+++ b/webhosting-operator/pkg/apis/config/v1alpha1/defaults.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -76,7 +76,7 @@ func SetDefaults_DebuggingConfiguration(obj *componentbaseconfigv1alpha1.Debuggi
 	componentbaseconfigv1alpha1.RecommendedDebuggingConfiguration(obj)
 
 	if obj.EnableContentionProfiling == nil {
-		obj.EnableContentionProfiling = pointer.Bool(false)
+		obj.EnableContentionProfiling = ptr.To(false)
 	}
 }
 

--- a/webhosting-operator/pkg/controllers/webhosting/suite_test.go
+++ b/webhosting-operator/pkg/controllers/webhosting/suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,7 +33,6 @@ import (
 )
 
 var (
-	cfg       *rest.Config
 	k8sClient client.Client
 	testEnv   *envtest.Environment
 )

--- a/webhosting-operator/pkg/controllers/webhosting/templates/testserver/server.go
+++ b/webhosting-operator/pkg/controllers/webhosting/templates/testserver/server.go
@@ -31,6 +31,7 @@ func main() {
 			http.Error(w, fmt.Sprintf("internal server error: %v", err), http.StatusInternalServerError)
 		}
 	})
+	// nolint:gosec // this is just for testing
 	if err := http.ListenAndServe(":9090", nil); err != nil {
 		panic(err)
 	}

--- a/webhosting-operator/pkg/experiment/generator/project.go
+++ b/webhosting-operator/pkg/experiment/generator/project.go
@@ -66,6 +66,7 @@ func CleanupProjects(ctx context.Context, c client.Client, labels map[string]str
 	}
 
 	for _, namespace := range namespaceList.Items {
+		// nolint:gosec // pointer doesn't outlive the loop iteration
 		if err := c.Delete(ctx, &namespace); err != nil {
 			return err
 		}

--- a/webhosting-operator/pkg/experiment/scenario.go
+++ b/webhosting-operator/pkg/experiment/scenario.go
@@ -50,7 +50,7 @@ func RegisterScenario(s Scenario) {
 
 // GetAllScenarios returns all registered scenarios.
 func GetAllScenarios() []Scenario {
-	var all []Scenario
+	all := make([]Scenario, 0, len(registry))
 	for _, s := range registry {
 		all = append(all, s)
 	}

--- a/webhosting-operator/pkg/experiment/scenario/base/base.go
+++ b/webhosting-operator/pkg/experiment/scenario/base/base.go
@@ -121,7 +121,7 @@ func (s *Scenario) Start(ctx context.Context) (err error) {
 	// give monitoring stack some time to observe objects
 	select {
 	case <-ctx.Done():
-		s.Log.Info("Scenario cancelled")
+		s.Log.Info("Scenario canceled")
 		return ctx.Err()
 	case <-time.After(30 * time.Second):
 	}
@@ -257,6 +257,7 @@ func (s *Scenario) waitForShardLeases(ctx context.Context) error {
 		for _, lease := range leaseList.Items {
 			state := lease.Labels["alpha.sharding.timebertt.dev/state"]
 			if state != "ready" {
+				// nolint:gosec // pointer doesn't outlive the loop iteration
 				lastError = fmt.Errorf("shard lease %s is in state %q", client.ObjectKeyFromObject(&lease), state)
 				return false, nil
 			}
@@ -272,11 +273,11 @@ func (s *Scenario) waitForShardLeases(ctx context.Context) error {
 	return nil
 }
 
-// Wait does blocks until the given duration has passed or returns an error when the context is cancelled.
+// Wait does blocks until the given duration has passed or returns an error when the context is canceled.
 func (s *Scenario) Wait(ctx context.Context, d time.Duration) error {
 	select {
 	case <-ctx.Done():
-		s.Log.Info("Scenario cancelled")
+		s.Log.Info("Scenario canceled")
 		return ctx.Err()
 	case <-time.After(d):
 	}

--- a/webhosting-operator/pkg/utils/utils.go
+++ b/webhosting-operator/pkg/utils/utils.go
@@ -22,6 +22,7 @@ import (
 
 // PickRandom picks a random element from the given slice.
 func PickRandom[T any](in []T) T {
+	// nolint:gosec // doesn't need to be cryptographically secure
 	return in[rand.Intn(len(in))]
 }
 
@@ -30,6 +31,7 @@ func RandomName(n int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyz"
 	result := make([]byte, n)
 	for i := range result {
+		// nolint:gosec // doesn't need to be cryptographically secure
 		result[i] = charset[rand.Intn(len(charset))]
 	}
 	return string(result)


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/timebertt/kubernetes-controller-sharding/pull/228 missed to adapt the `fmt` and `lint` recipes.
This PR follows up accordingly and fixes linter issues in webhosting-operator.