### PR TITLE
Test against k8s 1.28

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -132,8 +132,9 @@
       enabled: false
     },
     {
-      // kind k8s version should be updated together with shoot k8s version
+      // kind minor k8s version should be updated together with shoot k8s version
       matchPackageNames: ["kindest/node"],
+      matchUpdateTypes: ["minor"],
       enabled: false
     },
     {

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ WEBHOSTING_OPERATOR_IMG ?= $(GHCR_REPO)/webhosting-operator:$(TAG)
 EXPERIMENT_IMG ?= $(GHCR_REPO)/experiment:$(TAG)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.27
+ENVTEST_K8S_VERSION = 1.28
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.

--- a/hack/config/cert-manager/kustomization.yaml
+++ b/hack/config/cert-manager/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.yaml
+
+patches:
+# lower the webhook timeouts to make the webhooks compliant with gardener's requirements
+- path: patch-validatingwebhook.yaml
+- path: patch-mutatingwebhook.yaml

--- a/hack/config/cert-manager/patch-mutatingwebhook.yaml
+++ b/hack/config/cert-manager/patch-mutatingwebhook.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: cert-manager-webhook
+webhooks:
+- name: webhook.cert-manager.io
+  timeoutSeconds: 15

--- a/hack/config/cert-manager/patch-validatingwebhook.yaml
+++ b/hack/config/cert-manager/patch-validatingwebhook.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: cert-manager-webhook
+webhooks:
+- name: webhook.cert-manager.io
+  timeoutSeconds: 15

--- a/hack/config/kind-config.yaml
+++ b/hack/config/kind-config.yaml
@@ -2,7 +2,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.27.3
+  image: kindest/node:v1.28.7
   extraPortMappings:
   # ingress-nginx
   - containerPort: 30888

--- a/hack/config/shoot.yaml
+++ b/hack/config/shoot.yaml
@@ -24,7 +24,7 @@ spec:
       nodeCIDRMaskSize: 24
     kubeProxy:
       mode: IPTables
-    version: "1.27"
+    version: "1.28"
   maintenance:
     autoUpdate:
       kubernetesVersion: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades the Kubernetes version of the local kind cluster, the test shoot cluster, and envtest binaries to 1.28.
