### PR TITLE
Add renovate post update workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,31 @@
+name: renovate
+
+on:
+  push:
+    branches:
+    - renovate/*
+
+jobs:
+  post-update:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    # Some dependency updates might require updating go.work.sum.
+    # Automatically run `make tidy` on renovate branches as long as renovate doesn't know how to handle go workspaces.
+    # Some dependency updates might require re-running code generation.
+    # Run `make generate` and commit all changes if any.
+    - run: make tidy generate
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: make tidy generate
+        commit_user_name: renovate[bot]
+        commit_user_email: 29139614+renovate[bot]@users.noreply.github.com
+        commit_author: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>


### PR DESCRIPTION
**What this PR does / why we need it**:

Some dependency updates might require a `make tidy` or `make generate`, e.g., https://github.com/timebertt/kubernetes-controller-sharding/pull/316.
As you can only use renovate's [`postUpgradeTasks`](https://docs.renovatebot.com/configuration-options/#postupgradetasks) with self-hosted renovate instances, this PR adds a simple github actions workflow that runs the two make targets and commits any changes it finds.

This will increase the number of PRs that can be auto-merged.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
