### PR TITLE
Trigger another verify check by renovate post update action

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -9,23 +9,38 @@ jobs:
   post-update:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-
     steps:
     - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.RENOVATE_TOKEN }}
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
+
+    # prevent triggering infinite loop of this action
+    - name: safety check
+      id: safety
+      run: |
+        if git log -1 --pretty=full | grep '\[skip renovate-post-update\]' >/dev/null ; then
+          echo "Skipping renovate post update workflow"
+          echo "skip=true" >> $GITHUB_OUTPUT
+        fi
 
     # Some dependency updates might require updating go.work.sum.
     # Automatically run `make tidy` on renovate branches as long as renovate doesn't know how to handle go workspaces.
     # Some dependency updates might require re-running code generation.
     # Run `make generate` and commit all changes if any.
     - run: make tidy generate
+      if: steps.safety.outputs.skip != 'true'
     - uses: stefanzweifel/git-auto-commit-action@v5
+      if: steps.safety.outputs.skip != 'true'
       with:
-        commit_message: make tidy generate
+        commit_message: |
+          make tidy generate
+          
+          [skip renovate-post-update]
+
+        # commit with renovate's user, so that it doesn't block further updates to the PR
         commit_user_name: renovate[bot]
         commit_user_email: 29139614+renovate[bot]@users.noreply.github.com
         commit_author: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>


### PR DESCRIPTION
**What this PR does / why we need it**:

From https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow:

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

This PR works around this using a Personal Access Token scoped to this repository.
Infinite loops are prevented using a `[skip renovate-post-update]` commit message tag.

**Which issue(s) this PR fixes**:
Follow-up to https://github.com/timebertt/kubernetes-controller-sharding/pull/322.

**Special notes for your reviewer**:
