### PR TITLE
Test against k8s 1.31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ WEBHOSTING_OPERATOR_IMG ?= $(GHCR_REPO)/webhosting-operator:$(TAG)
 EXPERIMENT_IMG ?= $(GHCR_REPO)/experiment:$(TAG)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.28
+ENVTEST_K8S_VERSION = 1.31
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.

--- a/hack/config/kind-config.yaml
+++ b/hack/config/kind-config.yaml
@@ -2,7 +2,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.28.15
+  image: kindest/node:v1.31.4
   extraPortMappings:
   # ingress-nginx
   - containerPort: 30888

--- a/hack/config/shoot.yaml
+++ b/hack/config/shoot.yaml
@@ -24,7 +24,7 @@ spec:
       nodeCIDRMaskSize: 24
     kubeProxy:
       mode: IPTables
-    version: "1.28"
+    version: "1.31"
   maintenance:
     autoUpdate:
       kubernetesVersion: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades the Kubernetes version of the local kind cluster, the test shoot cluster, and envtest binaries to 1.31.