### PR TITLE
Fix kyverno webhook namespace selectors

### DIFF
--- a/hack/config/kyverno/kustomization.yaml
+++ b/hack/config/kyverno/kustomization.yaml
@@ -14,7 +14,7 @@ configMapGenerator:
   # overwrite default namespaceSelector for webhook configs to exclude kube-system
   # the second part makes gardeners care controller/webhook remediation happy
   - >-
-    webhooks=[{
+    webhooks={
       "namespaceSelector": {
         "matchExpressions": [{
           "key": "kubernetes.io/metadata.name",
@@ -26,4 +26,4 @@ configMapGenerator:
           "values": ["kube-system"]
         }]
       }
-    }]
+    }

--- a/hack/config/skaffold.yaml
+++ b/hack/config/skaffold.yaml
@@ -111,7 +111,7 @@ deploy:
               - |
                 for i in $(seq 1 20); do
                   # create dummy policy with dry-run enabled to test availability of webhook
-                  if kubectl create --raw "/apis/kyverno.io/v1/clusterpolicies?dryRun=All" -f <(echo '{"apiVersion": "kyverno.io/v1", "kind": "ClusterPolicy", "metadata": {"name": "test"}, "spec": {}}') >/dev/null ; then
+                  if kubectl create --dry-run=server -f <(yq '.metadata.name |= "test-kyverno"' hack/config/policy/shoot/sharder-scheduling.yaml) ; then
                     exit 0
                   fi
                   echo "Waiting until kyverno webhook is ready to handle policy creation"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the kyverno webhook namespace selectors after the breaking change in https://github.com/kyverno/kyverno/pull/11516.
Also, fix the skaffold hook for waiting for the kyverno webhook to be ready.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
