### PR TITLE
Replace deprecated `commonLabels` in kustomizations

### DIFF
--- a/config/certificate/kustomization.yaml
+++ b/config/certificate/kustomization.yaml
@@ -3,8 +3,10 @@ kind: Component
 
 namespace: sharding-system
 
-commonLabels:
-  app.kubernetes.io/name: controller-sharding
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: controller-sharding
 
 resources:
 - certificate.yaml

--- a/config/crds/kustomization.yaml
+++ b/config/crds/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-commonLabels:
-  app.kubernetes.io/name: controller-sharding
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: controller-sharding
 
 resources:
 - namespace.yaml

--- a/config/sharder/kustomization.yaml
+++ b/config/sharder/kustomization.yaml
@@ -6,8 +6,10 @@ namespace: sharding-system
 generatorOptions:
   disableNameSuffixHash: true
 
-commonLabels:
-  app.kubernetes.io/name: controller-sharding
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: controller-sharding
 
 images:
 - name: sharder

--- a/hack/config/monitoring/crds/kustomization.yaml
+++ b/hack/config/monitoring/crds/kustomization.yaml
@@ -2,10 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-commonLabels:
-  app.kubernetes.io/name: prometheus-operator
-  app.kubernetes.io/part-of: kube-prometheus
-  app.kubernetes.io/version: 0.76.2
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.76.2
 
 resources:
 - 0alertmanagerConfigCustomResourceDefinition.yaml

--- a/hack/config/monitoring/update.sh
+++ b/hack/config/monitoring/update.sh
@@ -40,10 +40,12 @@ cat <<EOF > kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-commonLabels:
-  app.kubernetes.io/name: prometheus-operator
-  app.kubernetes.io/part-of: kube-prometheus
-  app.kubernetes.io/version: $prometheus_operator_version
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: $prometheus_operator_version
 
 resources:
 $(ls *.yaml | sed 's/^/- /')

--- a/hack/config/shard/shard/kustomization.yaml
+++ b/hack/config/shard/shard/kustomization.yaml
@@ -3,9 +3,11 @@ kind: Kustomization
 
 namespace: default
 
-commonLabels:
-  app.kubernetes.io/name: controller-sharding
-  app.kubernetes.io/component: shard
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: controller-sharding
+    app.kubernetes.io/component: shard
 
 images:
 - name: shard

--- a/webhosting-operator/config/experiment/base/kustomization.yaml
+++ b/webhosting-operator/config/experiment/base/kustomization.yaml
@@ -3,8 +3,10 @@ kind: Kustomization
 
 namespace: experiment
 
-commonLabels:
-  app.kubernetes.io/name: experiment
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: experiment
 
 images:
 - name: experiment

--- a/webhosting-operator/config/manager/base/kustomization.yaml
+++ b/webhosting-operator/config/manager/base/kustomization.yaml
@@ -12,8 +12,10 @@ namespace: webhosting-system
 namePrefix: webhosting-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  app.kubernetes.io/name: webhosting-operator
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: webhosting-operator
 
 images:
 - name: controller

--- a/webhosting-operator/config/monitoring/webhosting-operator/kustomization.yaml
+++ b/webhosting-operator/config/monitoring/webhosting-operator/kustomization.yaml
@@ -3,8 +3,10 @@ kind: Kustomization
 
 namespace: webhosting-system
 
-commonLabels:
-  app.kubernetes.io/name: webhosting-operator
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: webhosting-operator
 
 resources:
 # provide prometheus running in namespace "monitoring" with the permissions required for service discovery in namespace


### PR DESCRIPTION
**What this PR does / why we need it**:

`commonLabels` is deprecated in kustomize. Replace all usages with `labels` with `includeSelectors=true`.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
