### PR TITLE
Fix validation message to say `ControllerRing`

### DIFF
--- a/config/crds/sharding.timebertt.dev_controllerrings.yaml
+++ b/config/crds/sharding.timebertt.dev_controllerrings.yaml
@@ -238,7 +238,7 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: ClusterRing name must not be longer than 63 characters
+        - message: ControllerRing name must not be longer than 63 characters
           rule: size(self.metadata.name) <= 63
     served: true
     storage: true

--- a/pkg/apis/sharding/v1alpha1/types_controllerring.go
+++ b/pkg/apis/sharding/v1alpha1/types_controllerring.go
@@ -28,7 +28,7 @@ import (
 //+kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.availableShards`
 //+kubebuilder:printcolumn:name="Shards",type=string,JSONPath=`.status.shards`
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
-//+kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63",message="ClusterRing name must not be longer than 63 characters"
+//+kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63",message="ControllerRing name must not be longer than 63 characters"
 
 // ControllerRing declares a virtual ring of sharded controller instances. Objects of the specified resources are
 // distributed across shards of this ring. Objects in all namespaces are considered unless a namespaceSelector is


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the validation message introduced in #441 to match https://github.com/timebertt/kubernetes-controller-sharding/pull/438.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
