### PR TITLE
Extract common controller predicates and handlers

### DIFF
--- a/pkg/controller/controllerring/add.go
+++ b/pkg/controller/controllerring/add.go
@@ -51,24 +51,12 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 
 	return builder.ControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(&shardingv1alpha1.ControllerRing{}, builder.WithPredicates(r.ControllerRingPredicate())).
+		For(&shardingv1alpha1.ControllerRing{}, builder.WithPredicates(shardingpredicate.ControllerRingCreatedOrUpdated())).
 		Watches(&coordinationv1.Lease{}, handler.EnqueueRequestsFromMapFunc(MapLeaseToControllerRing), builder.WithPredicates(r.LeasePredicate())).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 5,
 		}).
 		Complete(r)
-}
-
-func (r *Reconciler) ControllerRingPredicate() predicate.Predicate {
-	return predicate.And(
-		predicate.GenerationChangedPredicate{},
-		// ignore deletion of ControllerRings
-		predicate.Funcs{
-			CreateFunc: func(_ event.CreateEvent) bool { return true },
-			UpdateFunc: func(_ event.UpdateEvent) bool { return true },
-			DeleteFunc: func(_ event.DeleteEvent) bool { return false },
-		},
-	)
 }
 
 func MapLeaseToControllerRing(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/pkg/controller/controllerring/add.go
+++ b/pkg/controller/controllerring/add.go
@@ -17,8 +17,6 @@ limitations under the License.
 package controllerring
 
 import (
-	"context"
-
 	coordinationv1 "k8s.io/api/coordination/v1"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -28,9 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	shardingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/pkg/apis/sharding/v1alpha1"
+	shardinghandler "github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/handler"
 	shardingpredicate "github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/predicate"
 )
 
@@ -52,20 +50,15 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	return builder.ControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&shardingv1alpha1.ControllerRing{}, builder.WithPredicates(shardingpredicate.ControllerRingCreatedOrUpdated())).
-		Watches(&coordinationv1.Lease{}, handler.EnqueueRequestsFromMapFunc(MapLeaseToControllerRing), builder.WithPredicates(r.LeasePredicate())).
+		Watches(
+			&coordinationv1.Lease{},
+			handler.EnqueueRequestsFromMapFunc(shardinghandler.MapLeaseToControllerRing),
+			builder.WithPredicates(r.LeasePredicate()),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 5,
 		}).
 		Complete(r)
-}
-
-func MapLeaseToControllerRing(ctx context.Context, obj client.Object) []reconcile.Request {
-	ring, ok := obj.GetLabels()[shardingv1alpha1.LabelControllerRing]
-	if !ok {
-		return nil
-	}
-
-	return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: ring}}}
 }
 
 func (r *Reconciler) LeasePredicate() predicate.Predicate {

--- a/pkg/controller/sharder/add.go
+++ b/pkg/controller/sharder/add.go
@@ -50,24 +50,12 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 
 	return builder.ControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(&shardingv1alpha1.ControllerRing{}, builder.WithPredicates(r.ControllerRingPredicate())).
+		For(&shardingv1alpha1.ControllerRing{}, builder.WithPredicates(shardingpredicate.ControllerRingCreatedOrUpdated())).
 		Watches(&coordinationv1.Lease{}, handler.EnqueueRequestsFromMapFunc(MapLeaseToControllerRing), builder.WithPredicates(r.LeasePredicate())).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 5,
 		}).
 		Complete(r)
-}
-
-func (r *Reconciler) ControllerRingPredicate() predicate.Predicate {
-	return predicate.And(
-		predicate.GenerationChangedPredicate{},
-		// ignore deletion of ControllerRings
-		predicate.Funcs{
-			CreateFunc: func(_ event.CreateEvent) bool { return true },
-			UpdateFunc: func(_ event.UpdateEvent) bool { return true },
-			DeleteFunc: func(_ event.DeleteEvent) bool { return false },
-		},
-	)
 }
 
 func MapLeaseToControllerRing(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/pkg/controller/shardlease/add.go
+++ b/pkg/controller/shardlease/add.go
@@ -53,7 +53,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		Named(ControllerName).
 		For(&coordinationv1.Lease{}, builder.WithPredicates(r.LeasePredicate())).
 		// enqueue all Leases belonging to a ControllerRing when it is created or the spec is updated
-		Watches(&shardingv1alpha1.ControllerRing{}, handler.EnqueueRequestsFromMapFunc(r.MapControllerRingToLeases), builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&shardingv1alpha1.ControllerRing{}, handler.EnqueueRequestsFromMapFunc(r.MapControllerRingToLeases), builder.WithPredicates(shardingpredicate.ControllerRingCreatedOrUpdated())).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 5,
 		}).

--- a/pkg/controller/shardlease/add.go
+++ b/pkg/controller/shardlease/add.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	shardingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/pkg/apis/sharding/v1alpha1"
-	"github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/leases"
+	shardingpredicate "github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/predicate"
 )
 
 // ControllerName is the name of this controller.
@@ -61,24 +61,11 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 }
 
 func (r *Reconciler) LeasePredicate() predicate.Predicate {
-	// ignore deletion of shard leases
 	return predicate.And(
-		predicate.NewPredicateFuncs(isShardLease),
+		shardingpredicate.IsShardLease(),
+		shardingpredicate.ShardLeaseStateChanged(r.Clock),
+		// ignore deletion of shard leases
 		predicate.Funcs{
-			CreateFunc: func(_ event.CreateEvent) bool { return true },
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				oldLease, ok := e.ObjectOld.(*coordinationv1.Lease)
-				if !ok {
-					return false
-				}
-				newLease, ok := e.ObjectNew.(*coordinationv1.Lease)
-				if !ok {
-					return false
-				}
-
-				now := r.Clock.Now()
-				return leases.ToState(oldLease, now) != leases.ToState(newLease, now)
-			},
 			DeleteFunc: func(_ event.DeleteEvent) bool { return false },
 		},
 	)
@@ -100,8 +87,4 @@ func (r *Reconciler) MapControllerRingToLeases(ctx context.Context, obj client.O
 	}
 
 	return requests
-}
-
-func isShardLease(obj client.Object) bool {
-	return obj.GetLabels()[shardingv1alpha1.LabelControllerRing] != ""
 }

--- a/pkg/sharding/handler/controllerring.go
+++ b/pkg/sharding/handler/controllerring.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	shardingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/pkg/apis/sharding/v1alpha1"
+)
+
+var handlerLog = logf.Log.WithName("handler")
+
+// MapControllerRingToLeases maps a ControllerRing to all matching shard leases.
+func MapControllerRingToLeases(reader client.Reader) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		controllerRing, ok := obj.(*shardingv1alpha1.ControllerRing)
+		if !ok {
+			return nil
+		}
+
+		leaseList := &coordinationv1.LeaseList{}
+		if err := reader.List(ctx, leaseList, client.MatchingLabelsSelector{Selector: controllerRing.LeaseSelector()}); err != nil {
+			handlerLog.Error(err, "failed listing Leases for ControllerRing", "controllerRing", client.ObjectKeyFromObject(controllerRing))
+			return nil
+		}
+
+		requests := make([]reconcile.Request, 0, len(leaseList.Items))
+		for _, lease := range leaseList.Items {
+			requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&lease)})
+		}
+
+		return requests
+	}
+}

--- a/pkg/sharding/handler/controllerring_test.go
+++ b/pkg/sharding/handler/controllerring_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	shardingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/pkg/apis/sharding/v1alpha1"
+	. "github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/handler"
+)
+
+var _ = Describe("ControllerRing", func() {
+	var (
+		ctx context.Context
+
+		fakeClient client.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		fakeClient = fakeclient.NewFakeClient()
+	})
+
+	Describe("#MapControllerRingToLeases", func() {
+		var (
+			mapFunc handler.MapFunc
+
+			obj *shardingv1alpha1.ControllerRing
+		)
+
+		BeforeEach(func() {
+			mapFunc = MapControllerRingToLeases(fakeClient)
+
+			obj = &shardingv1alpha1.ControllerRing{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			}
+
+			lease := &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo-1",
+					Namespace: "foo-system",
+					Labels: map[string]string{
+						"alpha.sharding.timebertt.dev/controllerring": "foo",
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, lease.DeepCopy())).To(Succeed())
+
+			lease.Name = "foo-2"
+			Expect(fakeClient.Create(ctx, lease.DeepCopy())).To(Succeed())
+
+			lease.Name = "foo-3"
+			lease.Labels["alpha.sharding.timebertt.dev/controllerring"] = "bar"
+			Expect(fakeClient.Create(ctx, lease.DeepCopy())).To(Succeed())
+
+			lease.Name = "foo-4"
+			lease.Labels = nil
+			Expect(fakeClient.Create(ctx, lease.DeepCopy())).To(Succeed())
+		})
+
+		It("should ignore other object kinds", func() {
+			Expect(mapFunc(ctx, &corev1.Pod{})).To(BeEmpty())
+		})
+
+		It("should return requests for all matching leases", func() {
+			Expect(mapFunc(ctx, obj)).To(ConsistOf(
+				reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "foo-system", Name: "foo-1"}},
+				reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "foo-system", Name: "foo-2"}},
+			))
+		})
+	})
+})

--- a/pkg/sharding/handler/handler_suite_test.go
+++ b/pkg/sharding/handler/handler_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sharding Handlers Suite")
+}

--- a/pkg/sharding/handler/lease.go
+++ b/pkg/sharding/handler/lease.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	shardingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/pkg/apis/sharding/v1alpha1"
+)
+
+// MapLeaseToControllerRing maps a shard lease to its ControllerRing.
+func MapLeaseToControllerRing(_ context.Context, obj client.Object) []reconcile.Request {
+	ring := obj.GetLabels()[shardingv1alpha1.LabelControllerRing]
+	if ring == "" {
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: ring}}}
+}

--- a/pkg/sharding/handler/lease_test.go
+++ b/pkg/sharding/handler/lease_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	. "github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/handler"
+)
+
+var _ = Describe("Lease", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("#MapLeaseToControllerRing", func() {
+		var (
+			mapFunc handler.MapFunc
+
+			obj *coordinationv1.Lease
+		)
+
+		BeforeEach(func() {
+			mapFunc = MapLeaseToControllerRing
+
+			obj = &coordinationv1.Lease{}
+		})
+
+		It("should ignore unlabelled leases", func() {
+			Expect(mapFunc(ctx, obj)).To(BeEmpty())
+		})
+
+		It("should ignore leases with empty label", func() {
+			metav1.SetMetaDataLabel(&obj.ObjectMeta, "alpha.sharding.timebertt.dev/controllerring", "")
+			Expect(mapFunc(ctx, obj)).To(BeEmpty())
+		})
+
+		It("should correctly map leases with present label", func() {
+			metav1.SetMetaDataLabel(&obj.ObjectMeta, "alpha.sharding.timebertt.dev/controllerring", "foo")
+			Expect(mapFunc(ctx, obj)).To(ConsistOf(reconcile.Request{NamespacedName: client.ObjectKey{Name: "foo"}}))
+		})
+	})
+})

--- a/pkg/sharding/leases/state.go
+++ b/pkg/sharding/leases/state.go
@@ -31,7 +31,8 @@ const (
 	Unknown ShardState = iota
 	// Orphaned is the ShardState if the Lease has been in state Dead for at least 1 minute.
 	Orphaned
-	// Dead is the ShardState if the Lease is Uncertain and was successfully acquired by the sharder.
+	// Dead is the ShardState if the Lease is Uncertain and was successfully acquired by the sharder or if it was actively
+	// released by the shard.
 	Dead
 	// Uncertain is the ShardState if the Lease has expired at least leaseDuration ago.
 	Uncertain

--- a/pkg/sharding/predicate/controllerring.go
+++ b/pkg/sharding/predicate/controllerring.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ControllerRingCreatedOrUpdated reacts on create and update events with generation changes but ignores delete
+// events. On deletion, there is nothing to do for the sharding controllers.
+func ControllerRingCreatedOrUpdated() predicate.Predicate {
+	return predicate.And(
+		predicate.GenerationChangedPredicate{},
+		// ignore deletion of ControllerRings
+		predicate.Funcs{
+			CreateFunc: func(_ event.CreateEvent) bool { return true },
+			UpdateFunc: func(_ event.UpdateEvent) bool { return true },
+			DeleteFunc: func(_ event.DeleteEvent) bool { return false },
+		},
+	)
+}

--- a/pkg/sharding/predicate/controllerring_test.go
+++ b/pkg/sharding/predicate/controllerring_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	shardingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/pkg/apis/sharding/v1alpha1"
+	. "github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/predicate"
+)
+
+var _ = Describe("ControllerRing", func() {
+	var (
+		p predicate.Predicate
+
+		obj, objOld *shardingv1alpha1.ControllerRing
+	)
+
+	BeforeEach(func() {
+		obj = &shardingv1alpha1.ControllerRing{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: 1,
+			},
+		}
+		objOld = obj.DeepCopy()
+	})
+
+	Describe("#ControllerRingCreatedOrUpdated", func() {
+		BeforeEach(func() {
+			p = ControllerRingCreatedOrUpdated()
+		})
+
+		It("should react on create events", func() {
+			Expect(p.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+		})
+
+		It("should react on spec updates", func() {
+			obj.Generation++
+			obj.Spec.Resources = append(obj.Spec.Resources, shardingv1alpha1.RingResource{
+				GroupResource: metav1.GroupResource{Resource: "pods"},
+			})
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeTrue())
+		})
+
+		It("should ignore status updates", func() {
+			obj.Status.AvailableShards++
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+		})
+
+		It("should ignore delete events", func() {
+			Expect(p.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+		})
+	})
+})

--- a/pkg/sharding/predicate/lease.go
+++ b/pkg/sharding/predicate/lease.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	shardingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/pkg/apis/sharding/v1alpha1"
+	"github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/leases"
+)
+
+// IsShardLease filters for events on Lease objects that have a non-empty label specifying the ControllerRing.
+func IsShardLease() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		lease, ok := obj.(*coordinationv1.Lease)
+		if !ok {
+			return false
+		}
+
+		return lease.Labels[shardingv1alpha1.LabelControllerRing] != ""
+	})
+}
+
+// ShardLeaseStateChanged reacts on lease events where the shard's state changes.
+func ShardLeaseStateChanged(clock clock.PassiveClock) predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldLease, ok := e.ObjectOld.(*coordinationv1.Lease)
+			if !ok {
+				return false
+			}
+			newLease, ok := e.ObjectNew.(*coordinationv1.Lease)
+			if !ok {
+				return false
+			}
+
+			// only react if the shard's state changed
+			now := clock.Now()
+			return leases.ToState(oldLease, now) != leases.ToState(newLease, now)
+		},
+	}
+}
+
+// ShardLeaseAvailabilityChanged reacts on lease events where the shard's availability changes.
+func ShardLeaseAvailabilityChanged(clock clock.PassiveClock) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			lease, ok := e.Object.(*coordinationv1.Lease)
+			if !ok {
+				return false
+			}
+
+			// only react if the new shard is available right away
+			return leases.ToState(lease, clock.Now()).IsAvailable()
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldLease, ok := e.ObjectOld.(*coordinationv1.Lease)
+			if !ok {
+				return false
+			}
+			newLease, ok := e.ObjectNew.(*coordinationv1.Lease)
+			if !ok {
+				return false
+			}
+
+			// only react if the shard's availability changed
+			now := clock.Now()
+			return leases.ToState(oldLease, now).IsAvailable() != leases.ToState(newLease, now).IsAvailable()
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			lease, ok := e.Object.(*coordinationv1.Lease)
+			if !ok {
+				return false
+			}
+
+			if e.DeleteStateUnknown {
+				// If we missed the delete event, we cannot know the final state of the shard (available or not) for sure.
+				// The included object might be stale, as we might have missed a relevant update before as well.
+				// In this case, react for safety.
+				return true
+			}
+
+			// only react if the removed shard was still available
+			return leases.ToState(lease, clock.Now()).IsAvailable()
+		},
+	}
+}

--- a/pkg/sharding/predicate/lease_test.go
+++ b/pkg/sharding/predicate/lease_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/leases"
+	. "github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/predicate"
+)
+
+var _ = Describe("Lease", func() {
+	var (
+		p predicate.Predicate
+
+		fakeClock   *testing.FakePassiveClock
+		obj, objOld *coordinationv1.Lease
+	)
+
+	BeforeEach(func() {
+		fakeClock = testing.NewFakePassiveClock(time.Now())
+
+		obj = &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo-0",
+			},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity:       ptr.To("foo-0"),
+				LeaseDurationSeconds: ptr.To[int32](10),
+				AcquireTime:          ptr.To(metav1.NewMicroTime(fakeClock.Now().Add(-5 * time.Minute))),
+				RenewTime:            ptr.To(metav1.NewMicroTime(fakeClock.Now().Add(-2 * time.Second))),
+			},
+		}
+		metav1.SetMetaDataLabel(&obj.ObjectMeta, "alpha.sharding.timebertt.dev/controllerring", "foo")
+		objOld = obj.DeepCopy()
+	})
+
+	Describe("#IsShardLease", func() {
+		BeforeEach(func() {
+			p = IsShardLease()
+		})
+
+		It("should ignore other object kinds", func() {
+			pod := &corev1.Pod{}
+
+			Expect(p.Create(event.CreateEvent{Object: pod})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: pod, ObjectNew: pod})).To(BeFalse())
+			Expect(p.Delete(event.DeleteEvent{Object: pod})).To(BeFalse())
+		})
+
+		It("should ignore leases without label", func() {
+			delete(obj.Labels, "alpha.sharding.timebertt.dev/controllerring")
+			objOld = obj.DeepCopy()
+
+			Expect(p.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+			Expect(p.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+		})
+
+		It("should ignore leases with empty label", func() {
+			metav1.SetMetaDataLabel(&obj.ObjectMeta, "alpha.sharding.timebertt.dev/controllerring", "")
+			objOld = obj.DeepCopy()
+
+			Expect(p.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+			Expect(p.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+		})
+
+		It("should react on lease events with label", func() {
+			Expect(p.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeTrue())
+			Expect(p.Delete(event.DeleteEvent{Object: obj})).To(BeTrue())
+		})
+	})
+
+	Describe("#ShardLeaseStateChanged", func() {
+		BeforeEach(func() {
+			p = ShardLeaseStateChanged(fakeClock)
+		})
+
+		It("should react on all create events", func() {
+			Expect(p.Create(event.CreateEvent{})).To(BeTrue())
+		})
+
+		It("should react on all delete events", func() {
+			Expect(p.Delete(event.DeleteEvent{})).To(BeTrue())
+		})
+
+		It("should ignore other object kinds on update events", func() {
+			pod := &corev1.Pod{}
+
+			Expect(p.Update(event.UpdateEvent{ObjectOld: pod, ObjectNew: pod})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: pod})).To(BeFalse())
+		})
+
+		It("should react when shard state changed to dead (lease released)", func() {
+			obj.Spec.HolderIdentity = nil
+
+			Expect(leases.ToState(objOld, fakeClock.Now())).To(Equal(leases.Ready))
+			Expect(leases.ToState(obj, fakeClock.Now())).To(Equal(leases.Dead))
+
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeTrue())
+		})
+
+		It("should react when shard state changed to ready (renewed after expired)", func() {
+			objOld.Spec.RenewTime = ptr.To(metav1.NewMicroTime(fakeClock.Now().Add(-time.Duration(*obj.Spec.LeaseDurationSeconds+1) * time.Second)))
+
+			Expect(leases.ToState(objOld, fakeClock.Now())).To(Equal(leases.Expired))
+			Expect(leases.ToState(obj, fakeClock.Now())).To(Equal(leases.Ready))
+
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeTrue())
+		})
+
+		It("should ignore when shard state hasn't changed", func() {
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+
+			obj.Spec.HolderIdentity = nil
+			objOld.Spec.HolderIdentity = nil
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+		})
+	})
+
+	Describe("#ShardLeaseAvailabilityChanged", func() {
+		BeforeEach(func() {
+			p = ShardLeaseAvailabilityChanged(fakeClock)
+		})
+
+		It("should react on create events if shard is available", func() {
+			Expect(leases.ToState(obj, fakeClock.Now())).To(Equal(leases.Ready))
+			Expect(p.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+		})
+
+		It("should ignore create events if shard is not available", func() {
+			obj.Spec.HolderIdentity = nil
+			Expect(leases.ToState(obj, fakeClock.Now())).To(Equal(leases.Dead))
+			Expect(p.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+		})
+
+		It("should react on delete events if shard was available", func() {
+			Expect(leases.ToState(obj, fakeClock.Now())).To(Equal(leases.Ready))
+			Expect(p.Delete(event.DeleteEvent{Object: obj})).To(BeTrue())
+		})
+
+		It("should ignore delete events if shard was not available", func() {
+			obj.Spec.HolderIdentity = nil
+			Expect(leases.ToState(obj, fakeClock.Now())).To(Equal(leases.Dead))
+			Expect(p.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+		})
+
+		It("should ignore other object kinds", func() {
+			pod := &corev1.Pod{}
+
+			Expect(p.Create(event.CreateEvent{Object: pod})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: pod, ObjectNew: pod})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: pod})).To(BeFalse())
+			Expect(p.Delete(event.DeleteEvent{Object: pod})).To(BeFalse())
+		})
+
+		It("should react when shard state changed to dead (lease released)", func() {
+			obj.Spec.HolderIdentity = nil
+
+			Expect(leases.ToState(objOld, fakeClock.Now())).To(Equal(leases.Ready))
+			Expect(leases.ToState(obj, fakeClock.Now())).To(Equal(leases.Dead))
+
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeTrue())
+		})
+
+		It("should ignore when shard state changed to ready (renewed after expired)", func() {
+			objOld.Spec.RenewTime = ptr.To(metav1.NewMicroTime(fakeClock.Now().Add(-time.Duration(*obj.Spec.LeaseDurationSeconds+1) * time.Second)))
+
+			Expect(leases.ToState(objOld, fakeClock.Now())).To(Equal(leases.Expired))
+			Expect(leases.ToState(obj, fakeClock.Now())).To(Equal(leases.Ready))
+
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+		})
+
+		It("should react when shard state changed to ready (renewed after dead)", func() {
+			objOld.Spec.HolderIdentity = nil
+
+			Expect(leases.ToState(objOld, fakeClock.Now())).To(Equal(leases.Dead))
+			Expect(leases.ToState(obj, fakeClock.Now())).To(Equal(leases.Ready))
+
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeTrue())
+		})
+
+		It("should ignore when shard state hasn't changed", func() {
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+
+			obj.Spec.HolderIdentity = nil
+			objOld.Spec.HolderIdentity = nil
+			Expect(p.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+		})
+
+		It("should react if final delete state is unknown even if lease was unavailable", func() {
+			obj.Spec.HolderIdentity = nil
+
+			Expect(p.Delete(event.DeleteEvent{Object: obj, DeleteStateUnknown: true})).To(BeTrue())
+		})
+	})
+})

--- a/pkg/sharding/predicate/predicate_suite_test.go
+++ b/pkg/sharding/predicate/predicate_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPredicate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sharding Predicates Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extracts common predicates and handlers of the sharder's controllers.
It deduplicates them and adds unit test coverage.

**Which issue(s) this PR fixes**:
Part of https://github.com/timebertt/kubernetes-controller-sharding/issues/446

**Special notes for your reviewer**:
