### PR TITLE
renovate: automerge non-major `golang.org/x` updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,13 @@
       automerge: true,
     },
     {
+      // automerge non-major golang.org/x updates
+      matchDatasources: ['go'],
+      matchPackageNames: ['golang.org/x/*'],
+      matchUpdateTypes: ['minor', 'patch', 'digest'],
+      automerge: true,
+    },
+    {
       // disable automerge for go minor updates
       matchDatasources: ['golang-version'],
       matchUpdateTypes: ['minor'],


### PR DESCRIPTION
**What this PR does / why we need it**:

Inspired by https://github.com/gardener/gardener/pull/11591:

Automerge dependency updates like https://github.com/timebertt/kubernetes-controller-sharding/pull/494.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
