### PR TITLE
Drop event recorder from shard lease lock

### DIFF
--- a/cmd/checksum-controller/main.go
+++ b/cmd/checksum-controller/main.go
@@ -125,7 +125,7 @@ func (o *options) run(ctx context.Context) error {
 	}
 
 	log.Info("Setting up shard lease")
-	shardLease, err := shardlease.NewResourceLock(restConfig, nil, shardlease.Options{
+	shardLease, err := shardlease.NewResourceLock(restConfig, shardlease.Options{
 		ControllerRingName: o.controllerRingName,
 		LeaseNamespace:     o.leaseNamespace, // optional, can be empty
 		ShardName:          o.shardName,      // optional, can be empty

--- a/docs/implement-sharding.md
+++ b/docs/implement-sharding.md
@@ -135,7 +135,7 @@ import (
 func run() error {
 	restConfig := config.GetConfigOrDie()
 
-	shardLease, err := shardlease.NewResourceLock(restConfig, nil, shardlease.Options{
+	shardLease, err := shardlease.NewResourceLock(restConfig, shardlease.Options{
 		ControllerRingName: "my-controllerring",
 	})
 	if err != nil {

--- a/test/integration/shard/lease/lease_test.go
+++ b/test/integration/shard/lease/lease_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Shard lease", func() {
 	}, OncePerOrdered)
 
 	JustBeforeEach(func() {
-		shardLease, err := shardlease.NewResourceLock(restConfig, nil, leaseOptions)
+		shardLease, err := shardlease.NewResourceLock(restConfig, leaseOptions)
 		Expect(err).NotTo(HaveOccurred())
 		mgrOptions.LeaderElectionResourceLockInterface = shardLease
 

--- a/webhosting-operator/cmd/webhosting-operator/main.go
+++ b/webhosting-operator/cmd/webhosting-operator/main.go
@@ -273,7 +273,7 @@ func (o *options) applyOptionsOverrides() error {
 
 		// SHARD LEASE
 		o.controllerRingName = "webhosting-operator"
-		shardLease, err := shardlease.NewResourceLock(o.restConfig, nil, shardlease.Options{
+		shardLease, err := shardlease.NewResourceLock(o.restConfig, shardlease.Options{
 			ControllerRingName: o.controllerRingName,
 		})
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting an event recorder on the shard lease lock before setting up the manager was not very pragmatic.
Also, recording events on shard leases isn't meaningful.
Hence, this PR drops the event recorder handling from the shard lease lock for simplicity.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:
