### PR TITLE
Don't add internal dependency updates to release notes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -138,6 +138,12 @@
       matchUpdateTypes: ['minor'],
       enabled: false,
     },
+    // don't add internal dependency updates to release notes
+    {
+      matchFileNames: ["hack/config/**", "hack/tools.mk"],
+      matchPackageNames: ["!kubernetes-sigs/controller-tools", "!ko-build/ko"],
+      addLabels: ['no-release-note']
+    },
     {
       // combine upgrade of manifests and image tag in one PR
       groupName: 'external-dns',


### PR DESCRIPTION
**What this PR does / why we need it**:

The release notes are bloated with internal dependency updates (development and test tooling) that are not relevant to consumers of this repository.
This PR ensures such updates are not added to the release notes.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:
