### PR TITLE
Improve existing e2e test setup

### DIFF
--- a/cmd/checksum-controller/main.go
+++ b/cmd/checksum-controller/main.go
@@ -80,6 +80,7 @@ This example sharded controller is also useful for developing the sharding compo
 type options struct {
 	zapOptions         *zap.Options
 	controllerRingName string
+	namespace          string
 	leaseNamespace     string
 	shardName          string
 }
@@ -92,11 +93,13 @@ func newOptions() *options {
 		},
 
 		controllerRingName: "checksum-controller",
+		namespace:          metav1.NamespaceDefault,
 	}
 }
 
 func (o *options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.controllerRingName, "controllerring", o.controllerRingName, "Name of the ControllerRing the shard belongs to.")
+	fs.StringVar(&o.namespace, "namespace", o.namespace, "Namespace to watch objects in.")
 	fs.StringVar(&o.leaseNamespace, "lease-namespace", o.leaseNamespace, "Namespace to use for the shard lease. Defaults to the pod's namespace if running in-cluster.")
 	fs.StringVar(&o.shardName, "shard-name", o.shardName, "Name of the shard. Defaults to the instance's hostname.")
 
@@ -153,8 +156,8 @@ func (o *options) run(ctx context.Context) error {
 
 		// FILTERED WATCH CACHE
 		Cache: cache.Options{
-			// This controller only acts on objects in the default namespace.
-			DefaultNamespaces: map[string]cache.Config{metav1.NamespaceDefault: {}},
+			// This controller only acts on objects in a single configured namespace.
+			DefaultNamespaces: map[string]cache.Config{o.namespace: {}},
 			// Configure cache to only watch objects that are assigned to this shard.
 			// This controller only watches sharded objects, so we can configure the label selector on the cache's global level.
 			// If your controller watches sharded objects as well as non-sharded objects, use cache.Options.ByObject to configure

--- a/hack/config/checksum-controller/controller/deployment.yaml
+++ b/hack/config/checksum-controller/controller/deployment.yaml
@@ -13,7 +13,6 @@ spec:
       - name: checksum-controller
         image: checksum-controller:latest
         args:
-        - --controllerring=checksum-controller
         - --zap-log-level=debug
         env:
         - name: DISABLE_HTTP2

--- a/pkg/utils/test/matchers/condition.go
+++ b/pkg/utils/test/matchers/condition.go
@@ -18,7 +18,6 @@ package matchers
 
 import (
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -35,28 +34,20 @@ var MatchCondition = And
 
 // OfType returns a matcher for checking whether a condition has a certain type.
 func OfType(conditionType string) gomegatypes.GomegaMatcher {
-	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-		"Type": Equal(conditionType),
-	})
+	return HaveField("Type", Equal(conditionType))
 }
 
 // WithStatus returns a matcher for checking whether a condition has a certain status.
 func WithStatus(status metav1.ConditionStatus) gomegatypes.GomegaMatcher {
-	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-		"Status": Equal(status),
-	})
+	return HaveField("Status", Equal(status))
 }
 
 // WithReason returns a matcher for checking whether a condition has a certain reason.
 func WithReason(reason string) gomegatypes.GomegaMatcher {
-	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-		"Reason": Equal(reason),
-	})
+	return HaveField("Reason", Equal(reason))
 }
 
 // WithMessage returns a matcher for checking whether a condition has a certain message.
 func WithMessage(message string) gomegatypes.GomegaMatcher {
-	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-		"Message": ContainSubstring(message),
-	})
+	return HaveField("Message", ContainSubstring(message))
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -40,7 +40,8 @@ func TestE2E(t *testing.T) {
 }
 
 const (
-	ShortTimeout = 10 * time.Second
+	ShortTimeout  = 10 * time.Second
+	MediumTimeout = time.Minute
 )
 
 var (

--- a/test/e2e/example_test.go
+++ b/test/e2e/example_test.go
@@ -31,16 +31,16 @@ import (
 	. "github.com/timebertt/kubernetes-controller-sharding/pkg/utils/test/matchers"
 )
 
-var _ = Describe("Example Controller", Label("checksum-controller"), Ordered, func() {
-	const controllerRingName = "checksum-controller"
+const controllerRingName = "checksum-controller"
 
+var _ = Describe("Example Controller", Label("checksum-controller"), func() {
 	var controllerRing *shardingv1alpha1.ControllerRing
 
-	BeforeAll(func() {
+	BeforeEach(func() {
 		controllerRing = &shardingv1alpha1.ControllerRing{ObjectMeta: metav1.ObjectMeta{Name: controllerRingName}}
-	})
+	}, OncePerOrdered)
 
-	Describe("setup", func() {
+	Describe("setup", Ordered, func() {
 		It("the Deployment should be healthy", func(ctx SpecContext) {
 			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: controllerRingName, Namespace: metav1.NamespaceDefault}}
 			Eventually(ctx, Object(deployment)).Should(And(
@@ -73,7 +73,7 @@ var _ = Describe("Example Controller", Label("checksum-controller"), Ordered, fu
 		}, SpecTimeout(ShortTimeout))
 	})
 
-	Describe("creating objects", func() {
+	Describe("creating objects", Ordered, func() {
 		var (
 			secret *corev1.Secret
 			shard  string
@@ -94,7 +94,7 @@ var _ = Describe("Example Controller", Label("checksum-controller"), Ordered, fu
 		})
 
 		It("should assign the main object to a healthy shard", func(ctx SpecContext) {
-			shards := getReadyShards(ctx, controllerRingName)
+			shards := getReadyShards(ctx)
 
 			Expect(testClient.Create(ctx, secret)).To(Succeed())
 			log.Info("Created object", "secret", client.ObjectKeyFromObject(secret))
@@ -119,7 +119,7 @@ var _ = Describe("Example Controller", Label("checksum-controller"), Ordered, fu
 	})
 })
 
-func getReadyShards(ctx SpecContext, controllerRingName string) []string {
+func getReadyShards(ctx SpecContext) []string {
 	GinkgoHelper()
 
 	leaseList := &coordinationv1.LeaseList{}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the basic e2e tests to prepare for more advanced test cases.
Most notably, each test case now runs in its isolated namespace with a dedicated instance of the example controller.
This allows for simple test cleanup and ensures a clean test environment for every test case.
In more advanced cases, we can add/delete shards without worrying about leaving a clean state.
Doing this in a single namespace (where the controller is already deployed) is tedious and can easily leave a dirty state.

**Which issue(s) this PR fixes**:
Preparation for https://github.com/timebertt/kubernetes-controller-sharding/issues/448

**Special notes for your reviewer**:
