### PR TITLE
Add more e2e tests with example controller

### DIFF
--- a/cmd/checksum-controller/reconciler.go
+++ b/cmd/checksum-controller/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -112,6 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "checksums-" + secret.Name,
 			Namespace: secret.Namespace,
+			Labels:    maps.Clone(secret.Labels),
 		},
 		Data: make(map[string]string, len(secret.Data)),
 	}

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -6,4 +6,4 @@ set -o errexit
 
 source "$(dirname "$0")/test-e2e.env"
 
-ginkgo run --timeout=1h --poll-progress-after=60s --poll-progress-interval=30s --randomize-all --randomize-suites --keep-going --vv "$@"
+ginkgo run --timeout=1h --poll-progress-after=60s --poll-progress-interval=30s --randomize-all --randomize-suites --keep-going -v --show-node-events "$@"

--- a/pkg/utils/test/matchers/object.go
+++ b/pkg/utils/test/matchers/object.go
@@ -22,16 +22,26 @@ import (
 )
 
 // HaveName succeeds if the actual object has a matching name.
-func HaveName(name interface{}) gomegatypes.GomegaMatcher {
+func HaveName(name string) gomegatypes.GomegaMatcher {
 	return HaveField("ObjectMeta.Name", name)
 }
 
+// HaveNames succeeds if the actual list consists of matching names.
+func HaveNames(names ...string) gomegatypes.GomegaMatcher {
+	matchers := make([]any, len(names))
+	for i, n := range names {
+		matchers[i] = HaveName(n)
+	}
+
+	return HaveField("Items", ConsistOf(matchers...))
+}
+
 // HaveLabel succeeds if the actual object has a label with a matching key.
-func HaveLabel(key interface{}) gomegatypes.GomegaMatcher {
+func HaveLabel(key any) gomegatypes.GomegaMatcher {
 	return HaveField("ObjectMeta.Labels", HaveKey(key))
 }
 
 // HaveLabelWithValue succeeds if the actual object has a label with a matching key and value.
-func HaveLabelWithValue(key, value interface{}) gomegatypes.GomegaMatcher {
+func HaveLabelWithValue(key, value any) gomegatypes.GomegaMatcher {
 	return HaveField("ObjectMeta.Labels", HaveKeyWithValue(key, value))
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -69,6 +69,9 @@ var _ = BeforeSuite(func() {
 
 	restConfig, err := config.GetConfig()
 	Expect(err).NotTo(HaveOccurred())
+	// gotta go fast during tests
+	restConfig.QPS = 100
+	restConfig.Burst = 150
 
 	scheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(

--- a/test/e2e/example_test.go
+++ b/test/e2e/example_test.go
@@ -180,20 +180,26 @@ var _ = Describe("Example Controller", Label(checksumControllerName), func() {
 		}, SpecTimeout(MediumTimeout))
 	})
 
-	Describe("removing a shard", Ordered, func() {
+	describeScaleController("adding a shard", 4)
+
+	describeScaleController("removing a shard", 2)
+})
+
+func describeScaleController(text string, replicas int32) {
+	Describe(text, Ordered, func() {
 		itControllerRingShouldBeReady(3, 3)
 		itShouldGetReadyShards(3)
 
 		objectLabels := itShouldCreateObjects()
 		itObjectsShouldBeAssignedToShards(objectLabels)
 
-		itShouldScaleTheController(2)
-		itControllerRingShouldHaveAvailableShard(2)
-		itShouldGetReadyShards(2)
+		itShouldScaleTheController(replicas)
+		itControllerRingShouldHaveAvailableShard(replicas)
+		itShouldGetReadyShards(int(replicas))
 
 		itObjectsShouldBeAssignedToShards(objectLabels)
 	})
-})
+}
 
 func itControllerRingShouldBeReady(expectedShards, expectedAvailableShards int) {
 	GinkgoHelper()
@@ -212,7 +218,7 @@ func itControllerRingShouldBeReady(expectedShards, expectedAvailableShards int) 
 	}, SpecTimeout(ShortTimeout))
 }
 
-func itControllerRingShouldHaveAvailableShard(expectedAvailableShards int) {
+func itControllerRingShouldHaveAvailableShard(expectedAvailableShards int32) {
 	GinkgoHelper()
 
 	It(fmt.Sprintf("the ControllerRing should be ready and should have %d available shards", expectedAvailableShards), func(ctx SpecContext) {

--- a/test/e2e/example_test.go
+++ b/test/e2e/example_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Example Controller", Label(checksumControllerName), func() {
 			))
 		}, SpecTimeout(ShortTimeout))
 
-		itControllerRingShouldBeReady(3, 3)
+		itControllerRingShouldBeReady()
 		itShouldGetReadyShards(3)
 
 		It("there should not be any shard leases other than the 3 ready leases", func(ctx SpecContext) {
@@ -117,7 +117,7 @@ var _ = Describe("Example Controller", Label(checksumControllerName), func() {
 			}}
 		})
 
-		itControllerRingShouldBeReady(3, 3)
+		itControllerRingShouldBeReady()
 		itShouldGetReadyShards(3)
 
 		It("should assign the main object to a healthy shard", func(ctx SpecContext) {
@@ -194,7 +194,7 @@ var _ = Describe("Example Controller", Label(checksumControllerName), func() {
 			*lease = *newLease(60)
 		})
 
-		itControllerRingShouldBeReady(3, 3)
+		itControllerRingShouldBeReady()
 
 		itShouldCreateShardLease(lease)
 		itShardShouldHaveState(lease, leases.Ready)
@@ -217,7 +217,7 @@ var _ = Describe("Example Controller", Label(checksumControllerName), func() {
 			*lease = *newLease(10)
 		})
 
-		itControllerRingShouldBeReady(3, 3)
+		itControllerRingShouldBeReady()
 
 		itShouldCreateShardLease(lease)
 		itShardShouldHaveState(lease, leases.Ready)
@@ -242,7 +242,7 @@ var _ = Describe("Example Controller", Label(checksumControllerName), func() {
 
 func describeScaleController(text string, replicas int32) {
 	Describe(text, Ordered, func() {
-		itControllerRingShouldBeReady(3, 3)
+		itControllerRingShouldBeReady()
 		itShouldGetReadyShards(3)
 
 		objectLabels := itShouldCreateObjects()
@@ -256,13 +256,13 @@ func describeScaleController(text string, replicas int32) {
 	})
 }
 
-func itControllerRingShouldBeReady(expectedShards, expectedAvailableShards int) {
+func itControllerRingShouldBeReady() {
 	GinkgoHelper()
 
 	It("the ControllerRing should be ready", func(ctx SpecContext) {
 		Eventually(ctx, Object(controllerRing)).Should(And(
-			HaveField("Status.Shards", BeEquivalentTo(expectedShards)),
-			HaveField("Status.AvailableShards", BeEquivalentTo(expectedAvailableShards)),
+			HaveField("Status.Shards", BeEquivalentTo(3)),
+			HaveField("Status.AvailableShards", BeEquivalentTo(3)),
 			HaveField("Status.Conditions", ConsistOf(
 				MatchCondition(
 					OfType(shardingv1alpha1.ControllerRingReady),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds more e2e tests with the example controller (checksum-controller).
With this, the e2e tests cover all steps and scenarios described in `getting-started.md` and a few more.

**Which issue(s) this PR fixes**:
Part of https://github.com/timebertt/kubernetes-controller-sharding/issues/448

**Special notes for your reviewer**:
