### PR TITLE
Add e2e tests for webhosting-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test-kyverno: $(KYVERNO) ## Run kyverno policy tests.
 
 .PHONY: test-e2e
 test-e2e: $(GINKGO) ## Run e2e tests.
-	./hack/test-e2e.sh $(GINKGO_FLAGS) ./test/e2e/...
+	./hack/test-e2e.sh $(GINKGO_FLAGS) ./test/e2e/... ./webhosting-operator/test/e2e/...
 
 .PHONY: skaffold-fix
 skaffold-fix: $(SKAFFOLD) ## Upgrade skaffold configuration to the latest apiVersion.

--- a/cmd/checksum-controller/reconciler.go
+++ b/cmd/checksum-controller/reconciler.go
@@ -117,6 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		},
 		Data: make(map[string]string, len(secret.Data)),
 	}
+	configMap.Labels["secret"] = secret.Name
 
 	// Calculate the checksum for every Secret key and populate it in the ConfigMap.
 	for key, data := range secret.Data {

--- a/hack/config/policy/ci/kustomization.yaml
+++ b/hack/config/policy/ci/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- no-requests.yaml

--- a/hack/config/policy/ci/no-requests.yaml
+++ b/hack/config/policy/ci/no-requests.yaml
@@ -1,0 +1,46 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: no-requests-limits
+spec:
+  failurePolicy: Fail
+  rules:
+  # drop resource requests to allow scheduling all controller instances on a resource-restricted kind cluster (e.g., in CI)
+  - name: no-requests-limits
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - controller-sharding
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - sharder
+              - checksum-controller
+          operations:
+          - CREATE
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - webhosting-operator
+          operations:
+          - CREATE
+    mutate:
+      foreach:
+      - list: request.object.spec.containers
+        patchStrategicMerge:
+          spec:
+            containers:
+            - (name): "{{element.name}}"
+              resources: null

--- a/hack/config/skaffold.yaml
+++ b/hack/config/skaffold.yaml
@@ -109,6 +109,10 @@ deploy:
               - bash
               - -c
               - |
+                kubectl wait --for=condition=Available=true deploy -n kyverno kyverno-admission-controller --timeout=120s
+                kubectl wait --for=create validatingwebhookconfiguration kyverno-policy-validating-webhook-cfg
+                kubectl wait --for=create mutatingwebhookconfiguration kyverno-resource-mutating-webhook-cfg
+
                 for i in $(seq 1 20); do
                   # create dummy policy with dry-run enabled to test availability of webhook
                   if kubectl create --dry-run=server -f <(yq '.metadata.name |= "test-kyverno"' hack/config/policy/shoot/sharder-scheduling.yaml) ; then
@@ -141,11 +145,36 @@ profiles:
             - --server-side
             - --force-conflicts
         defaultNamespace: ""
+  - name: ci
+    activation:
+      - env: CI=.+
+    manifests:
+      kustomize:
+        paths:
+          - hack/config/policy/ci
+    deploy:
+      kubectl:
+        flags:
+          apply:
+            - --server-side
+            - --force-conflicts
+        defaultNamespace: ""
+        hooks:
+          after:
+          - host:
+              command:
+              - /usr/bin/env
+              - bash
+              - -c
+              - kubectl wait --for=condition=Ready=true clusterpolicy no-requests-limits --timeout=30s
 ---
 apiVersion: skaffold/v4beta12
 kind: Config
 metadata:
   name: sharder
+requires:
+  - configs:
+      - policy
 build:
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/sharder
@@ -191,6 +220,9 @@ apiVersion: skaffold/v4beta12
 kind: Config
 metadata:
   name: checksum-controller
+requires:
+  - configs:
+      - policy
 build:
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/checksum-controller
@@ -312,8 +344,8 @@ metadata:
   name: webhosting-operator
 requires:
   - configs:
+      - policy
       - monitoring-crds
-      - kyverno
 build:
   artifacts:
     - image: ghcr.io/timebertt/kubernetes-controller-sharding/webhosting-operator
@@ -389,6 +421,7 @@ metadata:
   name: experiment
 requires:
   - configs:
+      - policy
       - monitoring-crds
 profiles:
   - name: expirement

--- a/webhosting-operator/cmd/webhosting-operator/main.go
+++ b/webhosting-operator/cmd/webhosting-operator/main.go
@@ -272,7 +272,7 @@ func (o *options) applyOptionsOverrides() error {
 		}
 
 		// SHARD LEASE
-		o.controllerRingName = "webhosting-operator"
+		o.controllerRingName = webhostingv1alpha1.WebhostingOperatorName
 		shardLease, err := shardlease.NewResourceLock(o.restConfig, shardlease.Options{
 			ControllerRingName: o.controllerRingName,
 		})

--- a/webhosting-operator/pkg/apis/config/v1alpha1/defaults.go
+++ b/webhosting-operator/pkg/apis/config/v1alpha1/defaults.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
+
+	webhostingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/apis/webhosting/v1alpha1"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -65,10 +67,10 @@ func SetDefaults_LeaderElectionConfiguration(obj *componentbaseconfigv1alpha1.Le
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(obj)
 
 	if obj.ResourceName == "" {
-		obj.ResourceName = "webhosting-operator"
+		obj.ResourceName = webhostingv1alpha1.WebhostingOperatorName
 	}
 	if obj.ResourceNamespace == "" {
-		obj.ResourceNamespace = "webhosting-system"
+		obj.ResourceNamespace = webhostingv1alpha1.NamespaceSystem
 	}
 }
 

--- a/webhosting-operator/pkg/apis/webhosting/v1alpha1/constants.go
+++ b/webhosting-operator/pkg/apis/webhosting/v1alpha1/constants.go
@@ -21,6 +21,10 @@ import (
 )
 
 const (
+	// NamespaceSystem is the namespace where the webhosting-operator runs.
+	NamespaceSystem = "webhosting-system"
+	// WebhostingOperatorName is the name of the webhosting-operator Deployment, ControllerRing, etc.
+	WebhostingOperatorName = "webhosting-operator"
 	// LabelKeyProject is the label key on Namespaces for identifying webhosting projects.
 	LabelKeyProject = "webhosting.timebertt.dev/project"
 	// LabelValueProject is the label value for LabelKeyProject on Namespaces for identifying webhosting projects.

--- a/webhosting-operator/pkg/controllers/webhosting/website_controller.go
+++ b/webhosting-operator/pkg/controllers/webhosting/website_controller.go
@@ -438,7 +438,7 @@ func getLabelsForServer(serverName, name string) map[string]string {
 		"app":        "website",
 		"website":    name,
 		"server":     serverName,
-		"managed-by": "webhosting-operator",
+		"managed-by": webhostingv1alpha1.WebhostingOperatorName,
 	}
 }
 

--- a/webhosting-operator/pkg/controllers/webhosting/website_controller.go
+++ b/webhosting-operator/pkg/controllers/webhosting/website_controller.go
@@ -304,7 +304,7 @@ func (r *WebsiteReconciler) IngressForWebsite(serverName string, website *webhos
 
 	applyIngressConfigToIngress(r.Config.Ingress, ingress)
 
-	if isGeneratedByExperiment(website) {
+	if isGeneratedByE2ETestOrExperiment(website) {
 		// don't actually expose website ingresses in load tests
 		// use fake ingress class to prevent overloading ingress controller (this is not what we want to load test)
 		ingress.Spec.IngressClassName = ptr.To("fake")
@@ -424,7 +424,7 @@ func (r *WebsiteReconciler) DeploymentForWebsite(serverName string, website *web
 		},
 	}
 
-	if isGeneratedByExperiment(website) {
+	if isGeneratedByE2ETestOrExperiment(website) {
 		// don't actually run website pods in load tests
 		// otherwise, we would need an immense amount of compute power for running dummy websites
 		deployment.Spec.Replicas = ptr.To[int32](0)
@@ -611,6 +611,6 @@ var ConfigMapDataChanged = predicate.Funcs{
 	},
 }
 
-func isGeneratedByExperiment(obj client.Object) bool {
-	return obj.GetLabels()["generated-by"] == "experiment"
+func isGeneratedByE2ETestOrExperiment(obj client.Object) bool {
+	return obj.GetLabels()["e2e-webhosting-operator"] != "" || obj.GetLabels()["generated-by"] == "experiment"
 }

--- a/webhosting-operator/pkg/metrics/website.go
+++ b/webhosting-operator/pkg/metrics/website.go
@@ -144,8 +144,8 @@ var (
 				prometheus.GaugeValue,
 				1,
 				append(staticLabels,
-					website.Labels[shardingv1alpha1.LabelShard("webhosting-operator")],
-					website.Labels[shardingv1alpha1.LabelDrain("webhosting-operator")],
+					website.Labels[shardingv1alpha1.LabelShard(webhostingv1alpha1.WebhostingOperatorName)],
+					website.Labels[shardingv1alpha1.LabelDrain(webhostingv1alpha1.WebhostingOperatorName)],
 				)...,
 			)
 		},

--- a/webhosting-operator/test/e2e/e2e_suite_test.go
+++ b/webhosting-operator/test/e2e/e2e_suite_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	shardingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/pkg/apis/sharding/v1alpha1"
+	"github.com/timebertt/kubernetes-controller-sharding/pkg/utils/test"
+	. "github.com/timebertt/kubernetes-controller-sharding/pkg/utils/test/matchers"
+	webhostingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/apis/webhosting/v1alpha1"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhosting Operator E2E Test Suite")
+}
+
+const (
+	testID = "e2e-webhosting-operator"
+
+	ShortTimeout  = 10 * time.Second
+	MediumTimeout = time.Minute
+)
+
+var (
+	log logr.Logger
+
+	testClient client.Client
+
+	testRunID     string
+	testRunLabels map[string]string
+)
+
+var _ = BeforeSuite(func() {
+	log = zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)).WithName(testID)
+
+	restConfig, err := config.GetConfig()
+	Expect(err).NotTo(HaveOccurred())
+	// gotta go fast during tests
+	restConfig.QPS = 100
+	restConfig.Burst = 150
+
+	scheme := runtime.NewScheme()
+	schemeBuilder := runtime.NewSchemeBuilder(
+		clientgoscheme.AddToScheme,
+		shardingv1alpha1.AddToScheme,
+		webhostingv1alpha1.AddToScheme,
+	)
+	Expect(schemeBuilder.AddToScheme(scheme)).To(Succeed())
+
+	testClient, err = client.New(restConfig, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	clientContext, clientCancel := context.WithCancel(context.Background())
+	komega.SetClient(testClient)
+	komega.SetContext(clientContext)
+	DeferCleanup(clientCancel)
+
+	testRunID = testID + "-" + test.RandomSuffix()
+	testRunLabels = map[string]string{
+		testID: testRunID,
+	}
+	log = log.WithValues("testRun", testRunID)
+})
+
+var (
+	controllerRing *shardingv1alpha1.ControllerRing
+	namespace      *corev1.Namespace
+
+	controllerDeployment *appsv1.Deployment
+)
+
+var _ = BeforeEach(func(ctx SpecContext) {
+	By("Set up test Namespace")
+	namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		GenerateName: testRunID + "-",
+		Labels:       maps.Clone(testRunLabels),
+	}}
+	namespace.Labels[webhostingv1alpha1.LabelKeyProject] = webhostingv1alpha1.LabelValueProject
+
+	// We create a dedicated test namespace and clean it up for every test case to ensure a clean test environment.
+	Expect(testClient.Create(ctx, namespace)).To(Succeed())
+	log.Info("Created test Namespace", "namespace", namespace.Name)
+
+	DeferCleanup(func(ctx SpecContext) {
+		By("Delete all Websites in test Namespace")
+		Expect(testClient.DeleteAllOf(ctx, &webhostingv1alpha1.Website{}, client.InNamespace(namespace.Name))).To(Succeed())
+
+		By("Delete test Namespace")
+		Eventually(ctx, func() error {
+			return testClient.Delete(ctx, namespace)
+		}).Should(Or(Succeed(), BeNotFoundError()))
+	}, NodeTimeout(MediumTimeout))
+
+	By("Set up test ControllerRing")
+	controllerRing = &shardingv1alpha1.ControllerRing{ObjectMeta: metav1.ObjectMeta{Name: webhostingv1alpha1.WebhostingOperatorName}}
+
+	By("Scaling checksum-controller")
+	controllerDeployment = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: webhostingv1alpha1.WebhostingOperatorName, Namespace: webhostingv1alpha1.NamespaceSystem}}
+	scaleController(ctx, 3)
+
+	DeferCleanup(func(ctx SpecContext) {
+		By("Scaling checksum-controller")
+		scaleController(ctx, 3)
+	}, NodeTimeout(ShortTimeout))
+
+	By("Set up test Theme")
+	theme = &webhostingv1alpha1.Theme{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace.Name,
+			Labels: maps.Clone(testRunLabels),
+		},
+		Spec: webhostingv1alpha1.ThemeSpec{
+			Color:      "cyan",
+			FontFamily: "arial",
+		},
+	}
+	Expect(controllerutil.SetOwnerReference(namespace, theme, testClient.Scheme(), controllerutil.WithBlockOwnerDeletion(true))).To(Succeed())
+	Expect(testClient.Create(ctx, theme)).To(Succeed())
+}, NodeTimeout(MediumTimeout), OncePerOrdered)

--- a/webhosting-operator/test/e2e/webhosting_operator_test.go
+++ b/webhosting-operator/test/e2e/webhosting_operator_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2025 Tim Ebert.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	shardingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/pkg/apis/sharding/v1alpha1"
+	"github.com/timebertt/kubernetes-controller-sharding/pkg/sharding/leases"
+	"github.com/timebertt/kubernetes-controller-sharding/pkg/utils/test"
+	. "github.com/timebertt/kubernetes-controller-sharding/pkg/utils/test/matchers"
+	webhostingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/apis/webhosting/v1alpha1"
+)
+
+const objectCount = 100
+
+var (
+	mainObject        = &webhostingv1alpha1.Website{}
+	controlledObjects = []client.Object{
+		&appsv1.Deployment{},
+		&corev1.ConfigMap{},
+		&corev1.Service{},
+		&networkingv1.Ingress{},
+	}
+)
+
+var theme *webhostingv1alpha1.Theme
+
+var _ = Describe("Webhosting Operator", Label(webhostingv1alpha1.WebhostingOperatorName), func() {
+	Describe("setup", Ordered, func() {
+		itDeploymentShouldBeAvailable(3)
+		itControllerRingShouldHaveAvailableShards(3)
+		itShouldRecognizeReadyShardLeases(3)
+	})
+
+	Describe("creating a website", Ordered, func() {
+		var (
+			website *webhostingv1alpha1.Website
+			shard   string
+		)
+
+		itControllerRingShouldHaveAvailableShards(3)
+		itShouldRecognizeReadyShardLeases(3)
+
+		It("should assign the main object to a healthy shard", func(ctx SpecContext) {
+			// Verify that the sharder successfully injects the shard label.
+			// The webhook has failurePolicy=Ignore, so we might need to retry the creation until the injection succeeds.
+			Eventually(ctx, func(g Gomega) *webhostingv1alpha1.Website {
+				website = newWebsite("foo-" + test.RandomSuffix())
+				g.Expect(testClient.Create(ctx, website)).To(Succeed())
+				return website
+			}).Should(And(
+				HaveLabelWithValue(controllerRing.LabelShard(), BeElementOf(shards)),
+				Not(HaveLabel(controllerRing.LabelDrain())),
+			))
+			shard = website.Labels[controllerRing.LabelShard()]
+
+			log.Info("Created object", "website", client.ObjectKeyFromObject(website), "shard", shard)
+		}, SpecTimeout(MediumTimeout))
+
+		for _, obj := range controlledObjects {
+			It(fmt.Sprintf("should assign the controlled %T to the same shard", obj), func(ctx SpecContext) {
+				Eventually(ctx, ObjectList(listOf(obj), client.InNamespace(namespace.Name), client.MatchingLabels{"website": website.Name})).
+					Should(HaveField("Items", ConsistOf(And(
+						HaveLabelWithValue(controllerRing.LabelShard(), Equal(shard)),
+						Not(HaveLabel(controllerRing.LabelDrain())),
+					))))
+			}, SpecTimeout(MediumTimeout))
+		}
+
+		itWebsitesShouldBeReady()
+	})
+
+	describeScaleController("adding a shard", 4)
+
+	describeScaleController("removing a shard", 2)
+})
+
+func describeScaleController(text string, replicas int32) {
+	Describe(text, Ordered, func() {
+		itControllerRingShouldHaveAvailableShards(3)
+		itShouldRecognizeReadyShardLeases(3)
+
+		itCreateWebsites()
+		itShouldAssignObjectsToAvailableShards()
+		itWebsitesShouldBeReady()
+
+		itScaleController(replicas)
+		itDeploymentShouldBeAvailable(replicas)
+		itControllerRingShouldHaveAvailableShards(replicas)
+		itShouldRecognizeReadyShardLeases(int(replicas))
+
+		itShouldAssignObjectsToAvailableShards()
+		itWebsitesShouldBeReady()
+	})
+}
+
+func newWebsite(name string) *webhostingv1alpha1.Website {
+	return &webhostingv1alpha1.Website{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace.Name,
+			Labels:    maps.Clone(testRunLabels),
+		},
+		Spec: webhostingv1alpha1.WebsiteSpec{
+			Theme: theme.Name,
+		},
+	}
+}
+
+func itDeploymentShouldBeAvailable(expectedReplicas int32) {
+	GinkgoHelper()
+
+	It(fmt.Sprintf("the %s Deployment should be available", webhostingv1alpha1.WebhostingOperatorName), func(ctx SpecContext) {
+		Eventually(ctx, Object(controllerDeployment)).Should(And(
+			HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(expectedReplicas))),
+			HaveField("Status.Replicas", BeEquivalentTo(expectedReplicas)),
+			HaveField("Status.AvailableReplicas", BeEquivalentTo(expectedReplicas)),
+		))
+	}, SpecTimeout(MediumTimeout))
+}
+
+func itControllerRingShouldHaveAvailableShards(expectedAvailableShards int32) {
+	GinkgoHelper()
+
+	It(fmt.Sprintf("the ControllerRing should be ready and should have %d available shards", expectedAvailableShards), func(ctx SpecContext) {
+		Eventually(ctx, Object(controllerRing)).Should(And(
+			HaveField("Status.AvailableShards", BeEquivalentTo(expectedAvailableShards)),
+			HaveField("Status.Conditions", ConsistOf(
+				MatchCondition(
+					OfType(shardingv1alpha1.ControllerRingReady),
+					WithStatus(metav1.ConditionTrue),
+				),
+			)),
+		))
+	}, SpecTimeout(MediumTimeout))
+}
+
+var shards []string
+
+func itShouldRecognizeReadyShardLeases(expectedCount int) {
+	GinkgoHelper()
+
+	It(fmt.Sprintf("should recognize %d ready shard leases", expectedCount), func(ctx SpecContext) {
+		leaseList := &coordinationv1.LeaseList{}
+		Eventually(ctx, ObjectList(leaseList, client.InNamespace(controllerDeployment.Namespace), client.MatchingLabels{
+			shardingv1alpha1.LabelControllerRing: controllerRing.Name,
+			shardingv1alpha1.LabelState:          leases.Ready.String(),
+		})).Should(HaveField("Items", HaveLen(expectedCount)))
+
+		shards = make([]string, len(leaseList.Items))
+		for i, lease := range leaseList.Items {
+			shards[i] = lease.Name
+		}
+	}, SpecTimeout(ShortTimeout))
+}
+
+func itCreateWebsites() {
+	GinkgoHelper()
+
+	It(fmt.Sprintf("create %d websites", objectCount), func(ctx SpecContext) {
+		for i := 0; i < objectCount; i++ {
+			website := newWebsite("foo-" + strconv.Itoa(i))
+			Expect(testClient.Create(ctx, website)).To(Succeed(), "should create website %s", website.Name)
+		}
+	}, SpecTimeout(MediumTimeout))
+}
+
+func itWebsitesShouldBeReady() {
+	GinkgoHelper()
+
+	It("all Websites should be ready", func(ctx SpecContext) {
+		Eventually(ctx, ObjectList(&webhostingv1alpha1.WebsiteList{}, client.InNamespace(namespace.Name))).Should(
+			HaveField("Items", HaveEach(
+				HaveField("Status.Phase", webhostingv1alpha1.PhaseReady),
+			)),
+		)
+	}, SpecTimeout(MediumTimeout))
+}
+
+func itScaleController(replicas int32) {
+	GinkgoHelper()
+
+	It(fmt.Sprintf("scale the controller to %d replicas", replicas), func(ctx SpecContext) {
+		scaleController(ctx, replicas)
+	}, NodeTimeout(ShortTimeout))
+}
+
+func scaleController(ctx context.Context, replicas int32) {
+	GinkgoHelper()
+
+	patch := client.MergeFrom(&autoscalingv1.Scale{})
+	scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: replicas}}
+	Expect(testClient.SubResource("scale").Patch(ctx, controllerDeployment, patch, client.WithSubResourceBody(scale), &client.SubResourcePatchOptions{})).To(Succeed())
+
+	log.Info("Scaled controller", "replicas", replicas)
+}
+
+func itShouldAssignObjectsToAvailableShards() {
+	GinkgoHelper()
+
+	for _, obj := range append([]client.Object{mainObject}, controlledObjects...) {
+		It(fmt.Sprintf("should assign the %Ts to the available shards", obj), func(ctx SpecContext) {
+			eventuallyShouldAssignObjectsToAvailableShards(ctx, obj)
+		}, NodeTimeout(MediumTimeout))
+	}
+}
+
+func eventuallyShouldAssignObjectsToAvailableShards(ctx context.Context, obj client.Object) {
+	GinkgoHelper()
+
+	Eventually(ctx, func(g Gomega) {
+		list := listOf(obj)
+		g.Expect(ObjectList(list, client.InNamespace(namespace.Name), client.MatchingLabels(testRunLabels))()).To(HaveField("Items", HaveLen(objectCount)))
+
+		usedShards := sets.New[string]()
+		Expect(meta.EachListItem(list, func(obj runtime.Object) error {
+			g.Expect(obj).To(HaveLabelWithValue(controllerRing.LabelShard(), Not(BeEmpty())), "object %T %s should be assigned")
+			g.Expect(obj).NotTo(HaveLabel(controllerRing.LabelDrain()), "object %T %s should not have drain label")
+
+			usedShards.Insert(obj.(client.Object).GetLabels()[controllerRing.LabelShard()])
+			return nil
+		})).To(Succeed())
+
+		g.Expect(usedShards.UnsortedList()).To(ConsistOf(shards), "should use all available shards")
+	}).Should(Succeed())
+}
+
+func listOf(obj client.Object) client.ObjectList {
+	gvk, err := apiutil.GVKForObject(obj, testClient.Scheme())
+	Expect(err).NotTo(HaveOccurred())
+
+	gvk.Kind += "List"
+	list, err := testClient.Scheme().New(gvk)
+	Expect(err).NotTo(HaveOccurred())
+	return list.(client.ObjectList)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Simplify the e2e tests with checksum-controller and add e2e tests with webhosting-operator.
This should ensure, that changes don't accidentally break the evaluation scenarios with webhosting-operator.

**Which issue(s) this PR fixes**:
Fixes https://github.com/timebertt/kubernetes-controller-sharding/issues/448

**Special notes for your reviewer**:
