### PR TITLE
Enable non-major updates of `gomodules.xyz/jsonpatch`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -127,10 +127,11 @@
       automerge: true,
     },
     {
-      // jsonpatch has to be kept in sync with k8s and controller-runtime dependencies
+      // jsonpatch major version has to be kept in sync with k8s and controller-runtime dependencies
       matchDatasources: ['go'],
       matchPackageNames: ['gomodules.xyz/jsonpatch/*'],
-      enabled: false,
+      matchUpdateTypes: ['major'],
+      enabled: false
     },
     {
       // kind minor k8s version should be updated together with shoot k8s version


### PR DESCRIPTION
**What this PR does / why we need it**:

We only need to keep the `gomodules.xyz/jsonpatch` major version in sync with k8s and controller-runtime dependencies.
This PR enables non-major updates of the module again.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
