### PR TITLE
Add `kindest/node` digest and let renovate update it

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,6 +55,17 @@
         '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_VERSION *[?:]?= *"?(?<currentValue>.+?)"?\\s',
       ],
     },
+    {
+      // custom manager for updating kind node image tag and digest
+      customType: "regex",
+      managerFilePatterns: [
+        "/^Makefile$/",
+      ],
+      matchStrings: [
+        "(?<depName>kindest/node):(?<currentValue>[^@]+)(?:@(?<currentDigest>[^\\s]+))?",
+      ],
+      datasourceTemplate: "docker",
+    }
   ],
   packageRules: [
     {

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ kind-up kind-down: export KUBECONFIG = $(KIND_KUBECONFIG)
 
 .PHONY: kind-up
 kind-up: $(KIND) $(KUBECTL) ## Launch a kind cluster for local development and testing.
-	$(KIND) create cluster --name sharding --config hack/config/kind-config.yaml
+	$(KIND) create cluster --name sharding --config hack/config/kind-config.yaml --image kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 	# workaround https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
 	$(KUBECTL) get nodes -o name | cut -d/ -f2 | xargs -I {} docker exec {} sh -c "sysctl fs.inotify.max_user_instances=8192"
 	# run `export KUBECONFIG=$$PWD/hack/kind_kubeconfig.yaml` to target the created kind cluster.

--- a/hack/config/kind-config.yaml
+++ b/hack/config/kind-config.yaml
@@ -2,7 +2,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.31.9
   extraPortMappings:
   # ingress-nginx
   - containerPort: 30888


### PR DESCRIPTION
**What this PR does / why we need it**:

The kind release notes recommend pinning the `kindest/node` digest. This PR does so and teaches renovate to update it.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
