### PR TITLE
Add explicit `skip-workload` label for `Websites`

### DIFF
--- a/webhosting-operator/pkg/apis/webhosting/v1alpha1/constants.go
+++ b/webhosting-operator/pkg/apis/webhosting/v1alpha1/constants.go
@@ -29,6 +29,10 @@ const (
 	LabelKeyProject = "webhosting.timebertt.dev/project"
 	// LabelValueProject is the label value for LabelKeyProject on Namespaces for identifying webhosting projects.
 	LabelValueProject = "true"
+
+	// LabelKeySkipWorkload is the label key on Websites for instructing webhosting-operator to skip any actual workload
+	// for the website. Any value is accepted as truthy.
+	LabelKeySkipWorkload = "skip-workload"
 )
 
 var (

--- a/webhosting-operator/pkg/controllers/webhosting/website_controller.go
+++ b/webhosting-operator/pkg/controllers/webhosting/website_controller.go
@@ -304,7 +304,7 @@ func (r *WebsiteReconciler) IngressForWebsite(serverName string, website *webhos
 
 	applyIngressConfigToIngress(r.Config.Ingress, ingress)
 
-	if isGeneratedByE2ETestOrExperiment(website) {
+	if skipWorkload(website) {
 		// don't actually expose website ingresses in load tests
 		// use fake ingress class to prevent overloading ingress controller (this is not what we want to load test)
 		ingress.Spec.IngressClassName = ptr.To("fake")
@@ -424,7 +424,7 @@ func (r *WebsiteReconciler) DeploymentForWebsite(serverName string, website *web
 		},
 	}
 
-	if isGeneratedByE2ETestOrExperiment(website) {
+	if skipWorkload(website) {
 		// don't actually run website pods in load tests
 		// otherwise, we would need an immense amount of compute power for running dummy websites
 		deployment.Spec.Replicas = ptr.To[int32](0)
@@ -611,6 +611,9 @@ var ConfigMapDataChanged = predicate.Funcs{
 	},
 }
 
-func isGeneratedByE2ETestOrExperiment(obj client.Object) bool {
-	return obj.GetLabels()["e2e-webhosting-operator"] != "" || obj.GetLabels()["generated-by"] == "experiment"
+// skipWorkload returns true if the controller should not run any actual workload for this Website, e.g., for load tests
+// or e2e tests.
+func skipWorkload(website *webhostingv1alpha1.Website) bool {
+	_, ok := website.Labels[webhostingv1alpha1.LabelKeySkipWorkload]
+	return ok
 }

--- a/webhosting-operator/pkg/experiment/scenario/base/base.go
+++ b/webhosting-operator/pkg/experiment/scenario/base/base.go
@@ -80,6 +80,8 @@ func (s *Scenario) AddToManager(mgr manager.Manager) error {
 	s.Labels = map[string]string{
 		"generated-by": "experiment",
 		"scenario":     s.ScenarioName,
+
+		webhostingv1alpha1.LabelKeySkipWorkload: "true",
 	}
 
 	return mgr.Add(s)

--- a/webhosting-operator/test/e2e/webhosting_operator_test.go
+++ b/webhosting-operator/test/e2e/webhosting_operator_test.go
@@ -128,11 +128,14 @@ func describeScaleController(text string, replicas int32) {
 }
 
 func newWebsite(name string) *webhostingv1alpha1.Website {
+	labels := maps.Clone(testRunLabels)
+	labels[webhostingv1alpha1.LabelKeySkipWorkload] = "true"
+
 	return &webhostingv1alpha1.Website{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace.Name,
-			Labels:    maps.Clone(testRunLabels),
+			Labels:    labels,
 		},
 		Spec: webhostingv1alpha1.WebsiteSpec{
 			Theme: theme.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, `webhosting-operator` had logic to skip workload (`Ingress.spec.ingressClassName=fake`, `Deployment.spec.replicas=0`) specifically for e2e tests and `Websites` generated in `experiment`.
This PR inverts the dependency by adding a `skip-workload` label to `webhosting-operator`, making the logic independent from the use case.

The `sample-generator` is extended with a `--skip-workload` flag, which causes the new label to be set.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:
