### PR TITLE
Disable client-side rate limiting by default

### DIFF
--- a/pkg/apis/config/v1alpha1/defaults.go
+++ b/pkg/apis/config/v1alpha1/defaults.go
@@ -50,16 +50,6 @@ func SetDefaults_SharderConfig(obj *SharderConfig) {
 	}
 }
 
-func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.ClientConnectionConfiguration) {
-	// increase default rate limiter settings to make sharder and controller more responsive
-	if obj.QPS == 0 {
-		obj.QPS = 100
-	}
-	if obj.Burst == 0 {
-		obj.Burst = 150
-	}
-}
-
 func SetDefaults_LeaderElectionConfiguration(obj *componentbaseconfigv1alpha1.LeaderElectionConfiguration) {
 	if obj.ResourceLock == "" {
 		obj.ResourceLock = resourcelock.LeasesResourceLock

--- a/pkg/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/apis/config/v1alpha1/defaults_test.go
@@ -37,13 +37,10 @@ var _ = Describe("SharderConfig defaulting", func() {
 	})
 
 	Context("ClientConnectionConfiguration", func() {
-		It("should set default values", func() {
+		It("should not set any default values", func() {
 			SetObjectDefaults_SharderConfig(obj)
 
-			Expect(obj.ClientConnection).To(Equal(&componentbaseconfigv1alpha1.ClientConnectionConfiguration{
-				QPS:   100,
-				Burst: 150,
-			}))
+			Expect(obj.ClientConnection).To(Equal(&componentbaseconfigv1alpha1.ClientConnectionConfiguration{}))
 		})
 	})
 

--- a/pkg/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.defaults.go
@@ -35,9 +35,6 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_SharderConfig(in *SharderConfig) {
 	SetDefaults_SharderConfig(in)
-	if in.ClientConnection != nil {
-		SetDefaults_ClientConnectionConfiguration(in.ClientConnection)
-	}
 	if in.LeaderElection != nil {
 		SetDefaults_LeaderElectionConfiguration(in.LeaderElection)
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -70,9 +70,6 @@ var _ = BeforeSuite(func() {
 
 	restConfig, err := config.GetConfig()
 	Expect(err).NotTo(HaveOccurred())
-	// gotta go fast during tests
-	restConfig.QPS = 100
-	restConfig.Burst = 150
 
 	scheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(

--- a/webhosting-operator/cmd/experiment/main.go
+++ b/webhosting-operator/cmd/experiment/main.go
@@ -90,12 +90,8 @@ func main() {
 				log.Error(err, "Failed to set GOMAXPROCS")
 			}
 
-			restConfig := ctrl.GetConfigOrDie()
-			restConfig.QPS = 1000
-			restConfig.Burst = 1200
-
 			var err error
-			mgr, err = ctrl.NewManager(restConfig, ctrl.Options{
+			mgr, err = ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 				Scheme:                 scheme,
 				HealthProbeBindAddress: ":8081",
 				Metrics: metricsserver.Options{

--- a/webhosting-operator/config/manager/with-dns/config.yaml
+++ b/webhosting-operator/config/manager/with-dns/config.yaml
@@ -1,8 +1,5 @@
 apiVersion: config.webhosting.timebertt.dev/v1alpha1
 kind: WebhostingOperatorConfig
-clientConnection:
-  qps: 800
-  burst: 1000
 ingress:
   hosts:
   - webhosting.timebertt.dev

--- a/webhosting-operator/pkg/apis/config/v1alpha1/defaults.go
+++ b/webhosting-operator/pkg/apis/config/v1alpha1/defaults.go
@@ -49,16 +49,6 @@ func SetDefaults_WebhostingOperatorConfig(obj *WebhostingOperatorConfig) {
 	}
 }
 
-func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.ClientConnectionConfiguration) {
-	// increase default rate limiter settings to make sharder and controller more responsive
-	if obj.QPS == 0 {
-		obj.QPS = 100
-	}
-	if obj.Burst == 0 {
-		obj.Burst = 150
-	}
-}
-
 func SetDefaults_LeaderElectionConfiguration(obj *componentbaseconfigv1alpha1.LeaderElectionConfiguration) {
 	if obj.ResourceLock == "" {
 		obj.ResourceLock = resourcelock.LeasesResourceLock

--- a/webhosting-operator/pkg/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/webhosting-operator/pkg/apis/config/v1alpha1/zz_generated.defaults.go
@@ -35,9 +35,6 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_WebhostingOperatorConfig(in *WebhostingOperatorConfig) {
 	SetDefaults_WebhostingOperatorConfig(in)
-	if in.ClientConnection != nil {
-		SetDefaults_ClientConnectionConfiguration(in.ClientConnection)
-	}
 	if in.LeaderElection != nil {
 		SetDefaults_LeaderElectionConfiguration(in.LeaderElection)
 	}

--- a/webhosting-operator/test/e2e/e2e_suite_test.go
+++ b/webhosting-operator/test/e2e/e2e_suite_test.go
@@ -68,9 +68,6 @@ var _ = BeforeSuite(func() {
 
 	restConfig, err := config.GetConfig()
 	Expect(err).NotTo(HaveOccurred())
-	// gotta go fast during tests
-	restConfig.QPS = 100
-	restConfig.Burst = 150
 
 	scheme := runtime.NewScheme()
 	schemeBuilder := runtime.NewSchemeBuilder(


### PR DESCRIPTION
**What this PR does / why we need it**:

Similar to https://github.com/kubernetes-sigs/controller-runtime/pull/3119, this PR drops any default client-side rate limiter settings.
The config options are still available, but are no longer defaulted to 100 qps, 150 burst.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:
