### PR TITLE
Drop obsolete `go.uber.org/automaxprocs`

### DIFF
--- a/cmd/sharder/app/app.go
+++ b/cmd/sharder/app/app.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"go.uber.org/automaxprocs/maxprocs"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/klog/v2"
@@ -81,15 +80,6 @@ func NewCommand() *cobra.Command {
 }
 
 func run(ctx context.Context, log logr.Logger, opts *options) error {
-	// This is like importing the automaxprocs package for its init func (it will in turn call maxprocs.Set).
-	// Here we pass a custom logger, so that the result of the library gets logged to the same logger we use for the
-	// component itself.
-	if _, err := maxprocs.Set(maxprocs.Logger(func(s string, i ...interface{}) {
-		log.Info(fmt.Sprintf(s, i...))
-	})); err != nil {
-		log.Error(err, "Failed to set GOMAXPROCS")
-	}
-
 	log.Info("Setting up manager")
 	mgr, err := manager.New(opts.restConfig, opts.managerOptions)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/prometheus/client_golang v1.23.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
-	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/zap v1.27.0
 	gomodules.xyz/jsonpatch/v2 v2.5.0
 	k8s.io/api v0.33.4
@@ -76,6 +75,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.33.0 // indirect
 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
+	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.25.0 // indirect

--- a/webhosting-operator/cmd/experiment/main.go
+++ b/webhosting-operator/cmd/experiment/main.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
-	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -80,15 +79,6 @@ func main() {
 			ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 			log = ctrl.Log
 			klog.SetLogger(ctrl.Log)
-
-			// This is like importing the automaxprocs package for its init func (it will in turn call maxprocs.Set).
-			// Here we pass a custom logger, so that the result of the library gets logged to the same logger we use for the
-			// component itself.
-			if _, err := maxprocs.Set(maxprocs.Logger(func(s string, i ...interface{}) {
-				log.Info(fmt.Sprintf(s, i...))
-			})); err != nil {
-				log.Error(err, "Failed to set GOMAXPROCS")
-			}
 
 			var err error
 			mgr, err = ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/webhosting-operator/cmd/webhosting-operator/main.go
+++ b/webhosting-operator/cmd/webhosting-operator/main.go
@@ -24,7 +24,6 @@ import (
 	goruntime "runtime"
 	"strconv"
 
-	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap/zapcore"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -89,15 +88,6 @@ func main() {
 	if err := opts.Complete(); err != nil {
 		setupLog.Error(err, "unable to load config")
 		os.Exit(1)
-	}
-
-	// This is like importing the automaxprocs package for its init func (it will in turn call maxprocs.Set).
-	// Here we pass a custom logger, so that the result of the library gets logged to the same logger we use for the
-	// component itself.
-	if _, err := maxprocs.Set(maxprocs.Logger(func(s string, i ...interface{}) {
-		setupLog.Info(fmt.Sprintf(s, i...))
-	})); err != nil {
-		setupLog.Error(err, "Failed to set GOMAXPROCS")
 	}
 
 	mgr, err := ctrl.NewManager(opts.restConfig, opts.managerOptions)

--- a/webhosting-operator/go.mod
+++ b/webhosting-operator/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/prometheus/common v0.65.0
 	github.com/spf13/cobra v1.9.1
 	github.com/timebertt/kubernetes-controller-sharding v0.0.0
-	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/time v0.12.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -78,6 +77,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.33.0 // indirect
 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
+	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.41.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:

With #625, `automaxprocs` should no longer be needed, see https://tip.golang.org/doc/go1.25#container-aware-gomaxprocs:

> On Linux, the runtime considers the CPU bandwidth limit of the cgroup containing the process, if any. If the CPU bandwidth limit is lower than the number of logical CPUs available, GOMAXPROCS will default to the lower limit. In container runtime systems like Kubernetes, cgroup CPU bandwidth limits generally correspond to the “CPU limit” option. The Go runtime does not consider the “CPU requests” option.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
