### PR TITLE
sharder: log resyncs of object assignments

### DIFF
--- a/pkg/controller/sharder/reconciler.go
+++ b/pkg/controller/sharder/reconciler.go
@@ -19,6 +19,7 @@ package sharder
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
@@ -80,6 +81,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+
+	log.Info("Starting resync of object assignments for ControllerRing")
+	defer func(start time.Time) {
+		log.V(1).Info("Finished resync of object assignments for ControllerRing", "duration", r.Clock.Since(start))
+	}(r.Clock.Now())
 
 	if err := o.ResyncControllerRing(ctx, log); err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Small observability improvement: the sharder controller logs when it starts a resync for a `ControllerRing`. If debug logs are enabled, it also logs the duration of the resync when it finishes.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
