### PR TITLE
Simplify experiment metrics `run_id` label

### DIFF
--- a/hack/config/monitoring/default/patch_kubestatemetrics.yaml
+++ b/hack/config/monitoring/default/patch_kubestatemetrics.yaml
@@ -3,9 +3,11 @@
   path: /spec/template/spec/containers/0/args/-
   value:
     --namespaces=cert-manager,default,experiment,external-dns,ingress-nginx,kube-node-lease,kube-public,kube-system,kyverno,monitoring,parca,sharding-system,webhosting-system
-# add run_id label to kube_pod_labels to select metrics by experiment run ID
-# flag doesn't support wildcard patterns
+# label.prometheus.io/run_id is injected by experiment into observed pods (sharder and webhosting-operator).
+# Add the run_id label to kube_pod_labels. This allows joining cadvisor metrics with kube_pod_labels for selecting
+# metrics by experiment run ID.
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value:
+    # this flag doesn't support wildcard patterns
     --metric-labels-allowlist=pods=[label.prometheus.io/run_id]

--- a/webhosting-operator/config/experiment/base/servicemonitor.yaml
+++ b/webhosting-operator/config/experiment/base/servicemonitor.yaml
@@ -13,6 +13,8 @@ spec:
     relabelings:
     - targetLabel: job
       replacement: experiment
+    - targetLabel: run_id
+      sourceLabels: [__meta_kubernetes_pod_uid]
   selector:
     matchLabels:
       app.kubernetes.io/name: experiment

--- a/webhosting-operator/config/monitoring/default/dashboards/experiments.json
+++ b/webhosting-operator/config/monitoring/default/dashboards/experiments.json
@@ -18,8 +18,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": 5,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -46,6 +46,7 @@
             "seriesBy": "last"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -53,6 +54,7 @@
             "axisSoftMax": 10000,
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "opacity",
@@ -61,6 +63,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -82,8 +85,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -106,10 +108,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -138,11 +142,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "opacity",
@@ -151,6 +157,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -173,8 +180,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -205,10 +211,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -216,7 +224,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(\n    rate(controller_runtime_reconcile_total{\n        job=\"experiment\", result!=\"error\",\n        controller=~\"website-(generator|deleter|mutator)\"\n    }[$__rate_interval])\n    * on(namespace, pod) group_left\n    max by (namespace, pod, uid) (kube_pod_info{namespace=\"experiment\", pod=~\"experiment-.+\", uid=~\"$run_id\"})\n) by (controller)",
+          "expr": "sum(\n    rate(controller_runtime_reconcile_total{\n        job=\"experiment\", run_id=~\"$run_id\",\n        controller=~\"website-(generator|deleter|mutator)\",\n        result!=\"error\",\n    }[$__rate_interval])\n) by (controller)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -252,11 +260,13 @@
             "seriesBy": "last"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "opacity",
@@ -265,6 +275,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -287,8 +298,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -317,10 +327,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -351,11 +363,13 @@
             "seriesBy": "last"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "opacity",
@@ -364,6 +378,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -386,8 +401,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -416,10 +430,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -463,12 +479,14 @@
             "seriesBy": "last"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "opacity",
@@ -477,6 +495,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -498,8 +517,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -526,10 +544,12 @@
           "sortDesc": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -560,12 +580,14 @@
             "seriesBy": "last"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "opacity",
@@ -574,6 +596,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -595,8 +618,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -621,10 +643,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -655,12 +679,14 @@
             "seriesBy": "last"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "opacity",
@@ -669,6 +695,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -690,8 +717,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -716,10 +742,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -750,12 +778,14 @@
             "seriesBy": "last"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "opacity",
@@ -764,6 +794,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
@@ -785,8 +816,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -811,10 +841,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.1",
       "targets": [
         {
           "datasource": {
@@ -832,16 +864,15 @@
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": "10s",
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -853,19 +884,18 @@
           "type": "prometheus",
           "uid": "P1809F7CD0C75ACF3"
         },
-        "definition": "label_values(kube_pod_info{namespace=\"experiment\", pod=~\"experiment-.+\"},uid)",
-        "hide": 0,
+        "definition": "label_values(up{job=\"experiment\"},run_id)",
         "includeAll": true,
         "multi": true,
         "name": "run_id",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info{namespace=\"experiment\", pod=~\"experiment-.+\"},uid)",
+          "qryType": 1,
+          "query": "label_values(up{job=\"experiment\"},run_id)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       }
@@ -879,6 +909,5 @@
   "timezone": "",
   "title": "Experiments",
   "uid": "d33509b4-7e28-41e2-961a-4d7fbad57d01",
-  "version": 2,
-  "weekStart": ""
+  "version": 2
 }

--- a/webhosting-operator/pkg/experiment/scenario/base/base.go
+++ b/webhosting-operator/pkg/experiment/scenario/base/base.go
@@ -130,9 +130,7 @@ func (s *Scenario) Start(ctx context.Context) (err error) {
 	case <-time.After(30 * time.Second):
 	}
 
-	websiteTracker := &tracker.WebsiteTracker{
-		RunID: s.RunID,
-	}
+	websiteTracker := &tracker.WebsiteTracker{}
 	if err := websiteTracker.AddToManager(s.Manager); err != nil {
 		return fmt.Errorf("error adding website-tracker: %w", err)
 	}

--- a/webhosting-operator/pkg/experiment/tracker/website.go
+++ b/webhosting-operator/pkg/experiment/tracker/website.go
@@ -41,8 +41,6 @@ import (
 )
 
 var (
-	metricLabels = []string{"run_id"}
-
 	// NOTE: upper bound 5 is the SLO. Align buckets with SLO so that when p99 estimation grows above SLO we are sure
 	// that p99 is actually above SLO.
 	// See https://prometheus.io/docs/practices/histograms/#errors-of-quantile-estimation
@@ -55,7 +53,7 @@ var (
 		Help: "Latency from Website creation or spec update until the generation is observed as ready by a watch. " +
 			"This is an SLI for controller performance.",
 		Buckets: buckets,
-	}, metricLabels)
+	}, nil)
 	websiteBackfilledGenerations = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "experiment",
 		Subsystem: "website",
@@ -63,21 +61,18 @@ var (
 		Help: "Counter for Website generations that were never observed as ready before the next generation appeared. " +
 			"For such generations, the time when the next generation got ready is used for calculating the reconciliation latency. " +
 			"This metric serves as an indicator for how accurate the reconciliation latency measurement is.",
-	}, metricLabels)
+	}, nil)
 	watchLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "experiment",
 		Name:      "watch_latency_seconds",
 		Help: "Latency from Website transition time until observed by a watch event in experiment. " +
 			"This metric serves as an indicator for how experiment itself is performing to ensure accurate measurements.",
 		Buckets: buckets,
-	}, metricLabels)
+	}, nil)
 )
 
 // WebsiteTracker tracks how long it takes for generations of Website objects to be reconciled and get ready.
 type WebsiteTracker struct {
-	// RunID is added as the run_id label to metrics.
-	RunID string
-
 	reader client.Reader
 
 	// objects maps an object's UID to the object's generation information.
@@ -125,7 +120,7 @@ func (w *WebsiteTracker) AddToManager(mgr manager.Manager) error {
 	w.objects = newObjectsTracker()
 
 	// initialize counters
-	websiteBackfilledGenerations.WithLabelValues(w.RunID).Add(0)
+	websiteBackfilledGenerations.WithLabelValues().Add(0)
 
 	// register all metrics
 	metrics.Registry.MustRegister(websiteReconciliationLatency, websiteBackfilledGenerations, watchLatency)
@@ -177,7 +172,7 @@ func (w *WebsiteTracker) observedNewReadyGeneration() predicate.Predicate {
 
 			// Record how long it took experiment to observe the transition.
 			if t := website.Status.LastTransitionTime; t != nil && !t.Equal(oldWebsite.Status.LastTransitionTime) {
-				watchLatency.WithLabelValues(w.RunID).Observe(time.Since(t.Time).Seconds())
+				watchLatency.WithLabelValues().Observe(time.Since(t.Time).Seconds())
 			}
 
 			// if the status changed and the website is ready, we observed a new generation becoming ready
@@ -251,21 +246,21 @@ func (w *WebsiteTracker) Reconcile(ctx context.Context, req reconcile.Request) (
 
 	var res reconcile.Result
 	w.objects.set(uid, func(generations *objectGenerations) {
-		res = generations.reconcile(log, w.RunID)
+		res = generations.reconcile(log)
 	})
 	return res, nil
 }
 
 // reconcile iterates over the object's generations and records newly observed finished reconciliations in the latency
 // metric.
-func (o *objectGenerations) reconcile(log logr.Logger, runID string) reconcile.Result {
+func (o *objectGenerations) reconcile(log logr.Logger) reconcile.Result {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 
 	generations := generationsList(o.generations.sortedValues())
-	generations.backfillGenerations(runID)
+	generations.backfillGenerations()
 
-	if finished := generations.recordNewReadyGenerations(log, runID); !finished {
+	if finished := generations.recordNewReadyGenerations(log); !finished {
 		return reconcile.Result{Requeue: true}
 	}
 
@@ -278,7 +273,7 @@ type generationsList []*generationTimes
 // This might be necessary if we missed some watch events, or multiple generations were created in quick succession
 // where only a later one was reconciled by the controller to be ready.
 // The generations slice must be sorted by generation in ascending order.
-func (gg generationsList) backfillGenerations(runID string) {
+func (gg generationsList) backfillGenerations() {
 	var newerReadyTime time.Time
 	for i := len(gg) - 1; i >= 0; i-- {
 		g := gg[i]
@@ -291,7 +286,7 @@ func (gg generationsList) backfillGenerations(runID string) {
 			// this generation was not observed as ready,
 			// copy the ready time from the generation after it (if it has been observed as ready)
 			g.ready = newerReadyTime
-			websiteBackfilledGenerations.WithLabelValues(runID).Add(1)
+			websiteBackfilledGenerations.WithLabelValues().Add(1)
 		} else {
 			// this generation was observed as ready, copy the timestamp for backfilling earlier generations.
 			newerReadyTime = g.ready
@@ -301,7 +296,7 @@ func (gg generationsList) backfillGenerations(runID string) {
 
 // recordNewReadyGenerations records all newly observed ready generations.
 // Returns true if all generations have been recorded, false if there are unready generations left.
-func (gg generationsList) recordNewReadyGenerations(log logr.Logger, runID string) bool {
+func (gg generationsList) recordNewReadyGenerations(log logr.Logger) bool {
 	finished := true
 	for _, g := range gg {
 		if g.recorded {
@@ -319,7 +314,7 @@ func (gg generationsList) recordNewReadyGenerations(log logr.Logger, runID strin
 		}
 		log.V(logLevel).Info("Observed ready website", "latency", latency, "created", g.created, "ready", g.ready)
 
-		websiteReconciliationLatency.WithLabelValues(runID).Observe(latency.Seconds())
+		websiteReconciliationLatency.WithLabelValues().Observe(latency.Seconds())
 		g.recorded = true
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR simplifies how the `run_id` label is added to the metrics of `experiment`.
Instead of adding the `run_id` label explicitly, the `ServiceMonitor` copies the pod UID to the `run_id` label.
With this, all metrics from the `experiment` pods get the `run_id` label, not only the metrics from `webhosting-operator/pkg/experiment/tracker`.
For cadvisor metrics, we still need to join with `kube_pod_labels`.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:
