### PR TITLE
Add `chaos` experiment scenario

### DIFF
--- a/.run/experiment (kind).run.xml
+++ b/.run/experiment (kind).run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="experiment (kind)" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="kubernetes-controller-sharding" />
     <working_directory value="$PROJECT_DIR$/webhosting-operator" />
-    <parameters value="reconcile" />
+    <parameters value="basic" />
     <envs>
       <env name="KUBECONFIG" value="$PROJECT_DIR$/hack/kind_kubeconfig.yaml" />
     </envs>

--- a/config/sharder/deployment.yaml
+++ b/config/sharder/deployment.yaml
@@ -54,10 +54,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 256Mi
       volumes:
       - name: config
         configMap:

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -141,6 +141,21 @@ The scale of the controller setup is measured in two dimensions:
 1. The number of API objects that the controller watches and reconciles.
 2. The churn rate of API objects, i.e., the rate of object creations, updates, and deletions.
 
+```yaml
+queries:
+- name: website-count # dimension 1
+  query: |
+    sum(kube_website_info)
+- name: website-churn # dimension 2
+  query: |
+    sum(rate(
+      controller_runtime_reconcile_total{
+        job="experiment", result!="error",
+        controller=~"website-(generator|deleter|mutator)"
+      }[1m]
+    )) by (controller)
+```
+
 ## SLIs / SLOs
 
 To consider a controller setup as performing adequately, the following SLOs

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -75,8 +75,10 @@ Usage:
   experiment [command]
 
 Available Scenarios
-  basic       Basic load test scenario (15m) that creates roughly 9k websites
-  scale-out   Scenario for testing scale-out with high churn rate
+Available Scenarios
+  basic       Basic load test, create 9k websites in 15 minutes
+  chaos       Create 4.5k websites over 15 minutes and terminate a random shard every 5 minutes
+  scale-out   Measure scale-out properties with a high churn rate
 ...
 ```
 

--- a/pkg/controller/sharder/reconciler.go
+++ b/pkg/controller/sharder/reconciler.go
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	log.Info("Starting resync of object assignments for ControllerRing")
 	defer func(start time.Time) {
-		log.V(1).Info("Finished resync of object assignments for ControllerRing", "duration", r.Clock.Since(start))
+		log.Info("Finished resync of object assignments for ControllerRing", "duration", r.Clock.Since(start))
 	}(r.Clock.Now())
 
 	if err := o.ResyncControllerRing(ctx, log); err != nil {

--- a/webhosting-operator/config/experiment/base/rbac.yaml
+++ b/webhosting-operator/config/experiment/base/rbac.yaml
@@ -61,6 +61,15 @@ rules:
   - list
   - watch
   - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/webhosting-operator/config/experiment/chaos/kustomization.yaml
+++ b/webhosting-operator/config/experiment/chaos/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base
+
+patches:
+- target:
+    kind: Job
+    name: experiment
+  patch: |
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: chaos

--- a/webhosting-operator/config/monitoring/default/dashboards/experiments.json
+++ b/webhosting-operator/config/monitoring/default/dashboards/experiments.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 5,
+  "id": 35,
   "links": [],
   "panels": [
     {
@@ -340,10 +340,22 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        workqueue_queue_duration_seconds_bucket{\n            job=\"webhosting-operator\", name=\"website\", run_id=~\"$run_id\"\n        }[$__rate_interval]\n    ))\n)",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        workqueue_queue_duration_seconds_bucket{\n            job=\"webhosting-operator\", name=\"website\", run_id=~\"$run_id\"\n        }[1m]\n    ))\n)",
+          "legendFormat": "{{run_id}}-1m",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        workqueue_queue_duration_seconds_bucket{\n            job=\"webhosting-operator\", name=\"website\", run_id=~\"$run_id\"\n        }[15m]\n    ))\n)",
+          "hide": false,
+          "legendFormat": "{{run_id}}-15m",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Queue Latency (P99)",
@@ -443,10 +455,22 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        experiment_website_reconciliation_duration_seconds_bucket{\n            job=\"experiment\", run_id=~\"$run_id\"\n        }[$__rate_interval]\n    ))\n)",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        experiment_website_reconciliation_duration_seconds_bucket{\n            job=\"experiment\", run_id=~\"$run_id\"\n        }[1m]\n    ))\n)",
+          "legendFormat": "{{run_id}}-1m",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        experiment_website_reconciliation_duration_seconds_bucket{\n            job=\"experiment\", run_id=~\"$run_id\"\n        }[15m]\n    ))\n)",
+          "hide": false,
+          "legendFormat": "{{run_id}}-15m",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Reconciliation Latency (P99)",

--- a/webhosting-operator/config/monitoring/default/dashboards/experiments.json
+++ b/webhosting-operator/config/monitoring/default/dashboards/experiments.json
@@ -340,7 +340,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        workqueue_queue_duration_seconds_bucket{\n            job=\"webhosting-operator\", name=\"website\", run_id=~\"$run_id\"\n        }[1m]\n    ))\n)",
+          "expr": "histogram_quantile($percentile/100,\n    sum by (run_id, le) (rate(\n        workqueue_queue_duration_seconds_bucket{\n            job=\"webhosting-operator\", name=\"website\", run_id=~\"$run_id\"\n        }[1m]\n    ))\n)",
           "legendFormat": "{{run_id}}-1m",
           "range": true,
           "refId": "A"
@@ -351,14 +351,14 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        workqueue_queue_duration_seconds_bucket{\n            job=\"webhosting-operator\", name=\"website\", run_id=~\"$run_id\"\n        }[15m]\n    ))\n)",
+          "expr": "histogram_quantile($percentile/100,\n    sum by (run_id, le) (rate(\n        workqueue_queue_duration_seconds_bucket{\n            job=\"webhosting-operator\", name=\"website\", run_id=~\"$run_id\"\n        }[15m]\n    ))\n)",
           "hide": false,
           "legendFormat": "{{run_id}}-15m",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Queue Latency (P99)",
+      "title": "Queue Latency (P$percentile)",
       "type": "timeseries"
     },
     {
@@ -455,7 +455,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        experiment_website_reconciliation_duration_seconds_bucket{\n            job=\"experiment\", run_id=~\"$run_id\"\n        }[1m]\n    ))\n)",
+          "expr": "histogram_quantile($percentile/100,\n    sum by (run_id, le) (rate(\n        experiment_website_reconciliation_duration_seconds_bucket{\n            job=\"experiment\", run_id=~\"$run_id\"\n        }[1m]\n    ))\n)",
           "legendFormat": "{{run_id}}-1m",
           "range": true,
           "refId": "A"
@@ -466,14 +466,14 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n    sum by (run_id, le) (rate(\n        experiment_website_reconciliation_duration_seconds_bucket{\n            job=\"experiment\", run_id=~\"$run_id\"\n        }[15m]\n    ))\n)",
+          "expr": "histogram_quantile($percentile/100,\n    sum by (run_id, le) (rate(\n        experiment_website_reconciliation_duration_seconds_bucket{\n            job=\"experiment\", run_id=~\"$run_id\"\n        }[15m]\n    ))\n)",
           "hide": false,
           "legendFormat": "{{run_id}}-15m",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Reconciliation Latency (P99)",
+      "title": "Reconciliation Latency (P$percentile)",
       "type": "timeseries"
     },
     {
@@ -922,6 +922,33 @@
         "regex": "",
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {
+          "text": "99",
+          "value": "99"
+        },
+        "label": "SLO Percentile",
+        "name": "percentile",
+        "options": [
+          {
+            "selected": false,
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "selected": false,
+            "text": "95",
+            "value": "95"
+          },
+          {
+            "selected": true,
+            "text": "99",
+            "value": "99"
+          }
+        ],
+        "query": "90,95,99",
+        "type": "custom"
       }
     ]
   },

--- a/webhosting-operator/pkg/experiment/generator/reconciler.go
+++ b/webhosting-operator/pkg/experiment/generator/reconciler.go
@@ -65,7 +65,7 @@ func (r *Every) AddToManager(mgr manager.Manager) error {
 			MaxConcurrentReconciles: workers,
 			RateLimiter:             &workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(r.Rate, int(r.Rate))},
 		}).
-		WatchesRawSource(EmitN(workers)).
+		WatchesRawSource(EmitN(workers, 0)).
 		Complete(StopOnContextCanceled(r))
 }
 

--- a/webhosting-operator/pkg/experiment/generator/reconciler.go
+++ b/webhosting-operator/pkg/experiment/generator/reconciler.go
@@ -54,18 +54,33 @@ func (r *Every) AddToManager(mgr manager.Manager) error {
 		r.Client = mgr.GetClient()
 	}
 
+	initialDelay := time.Duration(0)
 	workers := defaultReconcileWorkers
 	if r.Workers > 0 {
 		workers = r.Workers
+	}
+
+	var rateLimiter workqueue.TypedRateLimiter[reconcile.Request] = &workqueue.TypedBucketRateLimiter[reconcile.Request]{
+		Limiter: rate.NewLimiter(r.Rate, int(r.Rate)),
+	}
+	if r.Rate < 1 {
+		// Special case for controllers running less frequent than every second:
+		// The token bucket rate limiter would not allow any events as burst is less than 1, so replace it with a custom
+		// rate limiter that always returns a constant delay.
+		// Also, delay the first request when starting the scenario.
+		every := time.Duration(1 / float64(r.Rate) * float64(time.Second))
+		rateLimiter = constantDelayRateLimiter(every)
+		initialDelay = every
+		workers = 1
 	}
 
 	return builder.ControllerManagedBy(mgr).
 		Named(r.Name).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: workers,
-			RateLimiter:             &workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(r.Rate, int(r.Rate))},
+			RateLimiter:             rateLimiter,
 		}).
-		WatchesRawSource(EmitN(workers, 0)).
+		WatchesRawSource(EmitN(workers, initialDelay)).
 		Complete(StopOnContextCanceled(r))
 }
 

--- a/webhosting-operator/pkg/experiment/generator/utils.go
+++ b/webhosting-operator/pkg/experiment/generator/utils.go
@@ -166,3 +166,12 @@ func CreateClusterScopedOwnerObject(ctx context.Context, c client.Client, opts .
 
 	return ownerObject, metav1.NewControllerRef(ownerObject, rbacv1.SchemeGroupVersion.WithKind("ClusterRole")), nil
 }
+
+var _ workqueue.TypedRateLimiter[reconcile.Request] = constantDelayRateLimiter(0)
+
+// constantDelayRateLimiter delays all requests with a constant duration.
+type constantDelayRateLimiter time.Duration
+
+func (d constantDelayRateLimiter) When(reconcile.Request) time.Duration { return time.Duration(d) }
+func (d constantDelayRateLimiter) Forget(reconcile.Request)             {}
+func (d constantDelayRateLimiter) NumRequeues(reconcile.Request) int    { return 0 }

--- a/webhosting-operator/pkg/experiment/generator/utils.go
+++ b/webhosting-operator/pkg/experiment/generator/utils.go
@@ -37,21 +37,21 @@ import (
 
 var log = logf.Log
 
-// EmitN returns a source that emits exactly n events (reconcile.Request). The source ignores predicates.
+// EmitN returns a source that emits exactly n reconcile requests with the given delay.
 // Use it with the controller builder:
 //
-//	WatchesRawSource(EmitN(n), &handler.EnqueueRequestForObject{})
+//	WatchesRawSource(EmitN(n, time.Second))
 //
 // Or a plain controller:
 //
-//	Watch(EmitN(n), &handler.EnqueueRequestForObject{})
-func EmitN(n int) source.Source {
+//	Watch(EmitN(n, time.Second))
+func EmitN(n int, delay time.Duration) source.Source {
 	return source.TypedFunc[reconcile.Request](func(ctx context.Context, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
 		for i := 0; i < n; i++ {
-			queue.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			queue.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{
 				// use different object names, otherwise queue will merge the requests
 				Name: fmt.Sprintf("request-%d", n),
-			}})
+			}}, delay)
 		}
 
 		return nil

--- a/webhosting-operator/pkg/experiment/scenario/all/all.go
+++ b/webhosting-operator/pkg/experiment/scenario/all/all.go
@@ -19,5 +19,6 @@ package all
 
 import (
 	_ "github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/experiment/scenario/basic"
+	_ "github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/experiment/scenario/chaos"
 	_ "github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/experiment/scenario/scale-out"
 )

--- a/webhosting-operator/pkg/experiment/scenario/chaos/chaos.go
+++ b/webhosting-operator/pkg/experiment/scenario/chaos/chaos.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Tim Ebert.
+Copyright 2025 Tim Ebert.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package basic
+package chaos
 
 import (
 	"context"
@@ -22,15 +22,18 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	webhostingv1alpha1 "github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/apis/webhosting/v1alpha1"
 	"github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/experiment"
 	"github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/experiment/generator"
 	"github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/experiment/scenario/base"
+	"github.com/timebertt/kubernetes-controller-sharding/webhosting-operator/pkg/utils"
 )
 
-const ScenarioName = "basic"
+const ScenarioName = "chaos"
 
 func init() {
 	s := &scenario{}
@@ -47,14 +50,14 @@ type scenario struct {
 }
 
 func (s *scenario) Description() string {
-	return "Basic load test, create 9k websites in 15 minutes"
+	return "Create 4.5k websites over 15 minutes and terminate a random shard every 5 minutes"
 }
 
 func (s *scenario) LongDescription() string {
-	return `The ` + ScenarioName + ` scenario combines several operations typical for a lively operator environment:
-- website creation: 10800 over 15m
-- website deletion: 1800 over 15m
-- website spec changes: 1/m per object, max 150/s
+	return `The ` + ScenarioName + ` scenario generates load and chaos for the webhosting-operator:
+- website creation: 4500 over 15m
+- website spec changes: 0.5/m per object, max 37.5/s
+- shard termination (pod deletion): 1/m
 `
 }
 
@@ -73,41 +76,63 @@ func (s *scenario) Prepare(ctx context.Context) error {
 }
 
 func (s *scenario) Run(ctx context.Context) error {
-	// website-generator: creates about 10800 websites over  15 minutes
-	// website-deleter:   deletes about  1800 websites over  15 minutes
-	// => in total, there will be about  9000 websites after 15 minutes
+	// website-generator: creates about 4500 websites over 15 minutes
 	if err := (&generator.Every{
 		Name: "website-generator",
 		Do: func(ctx context.Context, c client.Client) error {
 			return generator.CreateWebsite(ctx, c, generator.WithLabels(s.Labels))
 		},
-		Rate: rate.Limit(12),
+		Rate: rate.Limit(5),
 	}).AddToManager(s.Manager); err != nil {
 		return fmt.Errorf("error adding website-generator: %w", err)
 	}
 
-	if err := (&generator.Every{
-		Name: "website-deleter",
-		Do: func(ctx context.Context, c client.Client) error {
-			return generator.DeleteWebsite(ctx, c, s.Labels)
-		},
-		Rate: rate.Limit(2),
-	}).AddToManager(s.Manager); err != nil {
-		return fmt.Errorf("error adding website-deleter: %w", err)
-	}
-
-	// trigger individual spec changes for website once per minute
-	// => peaks at about 150 spec changes per second at the end of the experiment
+	// trigger individual spec changes for website every other minute
+	// => peaks at about 37.5 spec changes per second at the end of the experiment
 	// (triggers roughly double the reconciliation rate in website controller because of deployment watches)
 	if err := (&generator.ForEach[*webhostingv1alpha1.Website]{
 		Name: "website-mutator",
 		Do: func(ctx context.Context, c client.Client, obj *webhostingv1alpha1.Website) error {
 			return client.IgnoreNotFound(generator.MutateWebsite(ctx, c, obj, s.Labels))
 		},
-		Every: time.Minute,
+		Every: 2 * time.Minute,
 	}).AddToManager(s.Manager); err != nil {
 		return fmt.Errorf("error adding website-mutator: %w", err)
 	}
 
+	// Terminate a random shard every 5 minutes
+	if err := (&generator.Every{
+		Name: "shard-terminator",
+		Do:   terminateRandomShard,
+		Rate: rate.Every(5 * time.Minute),
+	}).AddToManager(s.Manager); err != nil {
+		return fmt.Errorf("error adding shard-terminator: %w", err)
+	}
+
 	return s.Wait(ctx, 15*time.Minute)
+}
+
+func terminateRandomShard(ctx context.Context, c client.Client) error {
+	log := logf.FromContext(ctx)
+
+	podList := &corev1.PodList{}
+	if err := c.List(ctx, podList,
+		client.InNamespace(webhostingv1alpha1.NamespaceSystem),
+		client.MatchingLabels{"app.kubernetes.io/name": webhostingv1alpha1.WebhostingOperatorName},
+	); err != nil {
+		return err
+	}
+
+	if len(podList.Items) == 0 {
+		log.Info("No shards found, skipping termination")
+		return nil
+	}
+
+	pod := utils.PickRandom(podList.Items)
+	if err := c.Delete(ctx, &pod); err != nil {
+		return err
+	}
+
+	log.Info("Terminated shard", "pod", client.ObjectKeyFromObject(&pod))
+	return nil
 }

--- a/webhosting-operator/pkg/experiment/scenario/scale-out/scale_out.go
+++ b/webhosting-operator/pkg/experiment/scenario/scale-out/scale_out.go
@@ -47,7 +47,7 @@ type scenario struct {
 }
 
 func (s *scenario) Description() string {
-	return "Scenario for testing scale-out with high churn rate"
+	return "Measure scale-out properties with a high churn rate"
 }
 
 func (s *scenario) LongDescription() string {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds another scenario to the `experiment` tool: `chaos`.
The scenario runs for 15 minutes, creates about 4.5k `Websites`, and terminates a random shard every 5 minutes.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:

With #647, I can run load test experiments on my shoot cluster reliably again. 
The `chaos` scenario reveals that it's hard to fulfill the P99 SLOs in a 15-minute time frame with multiple shard terminations. This will be even harder when performing a rolling update.

However, the results also show that the P99 SLI on a 1-minute time frame recovers quickly (~2m), now that the sharder performs drain/move operations concurrently (see #637).

P99 is not met:
<img width="3014" height="1492" alt="Screenshot 2025-08-24 at 18 49 40" src="https://github.com/user-attachments/assets/382c3e59-575a-4fe7-803e-77108ece3c97" />

P95 is met:
<img width="3012" height="1496" alt="Screenshot 2025-08-24 at 18 50 02" src="https://github.com/user-attachments/assets/24cc0ab7-4eec-420d-bf24-19a8f8e5d7dd" />
