### PR TITLE
Test against k8s 1.33

### DIFF
--- a/hack/config/shoot.yaml
+++ b/hack/config/shoot.yaml
@@ -29,7 +29,7 @@ spec:
       mode: IPTables
     kubelet:
       serializeImagePulls: false
-    version: "1.32"
+    version: "1.33"
   maintenance:
     autoUpdate:
       kubernetesVersion: true
@@ -62,7 +62,7 @@ spec:
       floatingPoolName: floating-net
       networks:
         workers: 10.250.0.0/16
-    type: openstack
+    type: stackit
     workers:
     # runs system and monitoring components (default worker pool)
     - name: system

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.32"}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.33"}
 
 # shellcheck disable=SC1090
 # --use-env allows overwriting the envtest tools path via the KUBEBUILDER_ASSETS env var


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades both the shoot and envtest version to k8s 1.33.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:
